### PR TITLE
Fix: error while installing via pip - decode error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@ PACKAGE = "pytest-allure-adaptor"
 VERSION = "1.5.2"
 
 import os
+import codecs
 from setuptools import setup
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return codecs.open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 setup(
     name=PACKAGE,


### PR DESCRIPTION
Fix for UnicodeDecodeError error while installing via pip 
pip install https://github.com/allure-framework/allure-python/archive/master.zip

    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "C:\Users\M\AppData\Local\Temp\pip-auonb2h2-build\setup.py", line 22, in <module>
        long_description=read('README.rst'),
      File "C:\Users\M\AppData\Local\Temp\pip-auonb2h2-build\setup.py", line 12, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "C:\Py34\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 4428: character maps to <undefin
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>
  File "C:\Users\M\AppData\Local\Temp\pip-auonb2h2-build\setup.py", line 22, in <module>
    long_description=read('README.rst'),
  File "C:\Users\M\AppData\Local\Temp\pip-auonb2h2-build\setup.py", line 12, in read
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
  File "C:\Py34\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 4428: character maps to <undefined>