### PR TITLE
support AttachmentType inheritance and extensibility

### DIFF
--- a/allure/constants.py
+++ b/allure/constants.py
@@ -6,7 +6,6 @@ Created on Oct 15, 2013
 @author: pupssman
 '''
 from collections import namedtuple
-from enum import Enum
 
 
 class Status(object):

--- a/allure/constants.py
+++ b/allure/constants.py
@@ -5,9 +5,8 @@ Created on Oct 15, 2013
 
 @author: pupssman
 '''
+from collections import namedtuple
 from enum import Enum
-
-from allure.utils import AttachTuple
 
 
 class Status(object):
@@ -32,6 +31,9 @@ class Severity(object):
     NORMAL = 'normal'
     MINOR = 'minor'
     TRIVIAL = 'trivial'
+
+
+AttachTuple = namedtuple('AttachTuple', ['mime_type', 'extension'])
 
 
 class AttachmentType(object):

--- a/allure/constants.py
+++ b/allure/constants.py
@@ -7,6 +7,8 @@ Created on Oct 15, 2013
 '''
 from enum import Enum
 
+from allure.utils import AttachTuple
+
 
 class Status(object):
     FAILED = 'failed'
@@ -32,19 +34,14 @@ class Severity(object):
     TRIVIAL = 'trivial'
 
 
-class AttachmentType(Enum):
-
-    def __init__(self, mime_type, extension):
-        self.mime_type = mime_type
-        self.extension = extension
-
-    TEXT = ("text/plain", "txt")
-    HTML = ("application/html", "html")
-    XML = ("application/xml", "xml")
-    PNG = ("image/png", "png")
-    JPG = ("image/jpg", "jpg")
-    JSON = ("application/json", "json")
-    OTHER = ("other", "other")
+class AttachmentType(object):
+    TEXT = AttachTuple("text/plain", "txt")
+    HTML = AttachTuple("application/html", "html")
+    XML = AttachTuple("application/xml", "xml")
+    PNG = AttachTuple("image/png", "png")
+    JPG = AttachTuple("image/jpg", "jpg")
+    JSON = AttachTuple("application/json", "json")
+    OTHER = AttachTuple("other", "other")
 
 
 ALLURE_NAMESPACE = "urn:model.allure.qatools.yandex.ru"

--- a/allure/utils.py
+++ b/allure/utils.py
@@ -12,6 +12,7 @@ import time
 import hashlib
 import inspect
 
+from collections import namedtuple
 from six import text_type, binary_type, python_2_unicode_compatible, u
 from six.moves import filter
 from traceback import format_exception_only
@@ -20,6 +21,8 @@ from _pytest.python import Module
 
 from allure.constants import Label
 
+
+AttachTuple = namedtuple('AttachTuple', ['mime_type', 'extension'])
 
 def parents_of(item):
     """

--- a/allure/utils.py
+++ b/allure/utils.py
@@ -12,7 +12,6 @@ import time
 import hashlib
 import inspect
 
-from collections import namedtuple
 from six import text_type, binary_type, python_2_unicode_compatible, u
 from six.moves import filter
 from traceback import format_exception_only
@@ -21,8 +20,6 @@ from _pytest.python import Module
 
 from allure.constants import Label
 
-
-AttachTuple = namedtuple('AttachTuple', ['mime_type', 'extension'])
 
 def parents_of(item):
     """

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ def main():
             "lxml>=3.2.0",
             "pytest>=2.4.1",
             "namedlist",
-            "six>=1.9.0",
-            "enum34"]
+            "six>=1.9.0"]
     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
I suppose it's good idea to have ability to make that:

```python
class attachment_type(AttachmentType):
    ZIP=AttachTuple('application/zip', 'zip')
```