### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - '2.6'
   - '2.7'
   - '3.3'
   - '3.4'

--- a/allure/rules.py
+++ b/allure/rules.py
@@ -124,6 +124,6 @@ def xmlfied(el_name, namespace='', fields=[], **kw):
             manys = sum([[(m[0], v) for v in m[1]] for m in entries(Many)], [])
 
             return el(*([element for (_, element) in elements + nested + manys]),
-                      **{name: attr for (name, attr) in attributes})
+                      **dict(attributes))
 
     return MyImpl

--- a/allure/utils.py
+++ b/allure/utils.py
@@ -118,7 +118,7 @@ def unicodify(something):
     if isinstance(something, text_type):
         return something
     elif isinstance(something, binary_type):
-        return something.decode('utf-8', errors='replace')
+        return something.decode('utf-8', 'replace')
     else:
         try:
             return text_type(something)  # @UndefinedVariable

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=py27,py33,py34,static_check
+envlist=py26,py27,py33,py34,static_check
 
 [testenv]
 deps=


### PR DESCRIPTION
Didn’t check `py33` because I don’t have Python 3.3 handy, but the other environments work OK, so there shouldn’t be any problems.