### PR TITLE
Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '3.3'
   - '3.4'
   - '3.5'
+sudo: false
 env:
   - TOX_ENV=py
   - TOX_ENV=static_check

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - '2.7'
   - '3.3'
   - '3.4'
+  - '3.5'
 env:
   - TOX_ENV=py
   - TOX_ENV=static_check

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,19 @@
 import os
+import sys
 from setuptools import setup
-
 
 PACKAGE = "pytest-allure-adaptor"
 VERSION = "1.6.8"
+
+install_requires = [
+    "lxml>=3.2.0",
+    "pytest>=2.7.3",
+    "namedlist",
+    "six>=1.9.0"
+]
+
+if sys.version_info < (3, 4):
+    install_requires.append("enum34")
 
 
 def read(fname):
@@ -21,13 +31,9 @@ def main():
         url="https://github.com/allure-framework/allure-python",
         long_description=read('README.rst'),
         entry_points={'pytest11': ['allure_adaptor = allure.pytest_plugin']},
-        install_requires=[
-            "lxml>=3.2.0",
-            "pytest>=2.7.0",
-            "namedlist",
-            "six>=1.9.0",
-            "enum34"]
+        install_requires=install_requires
     )
+
 
 if __name__ == '__main__':
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=py26,py27,py33,py34,static_check
+envlist=py26,py27,py33,py34,py35,static_check
 
 [testenv]
 deps=
-    pytest==2.7.0
+    pytest==2.7.3
     pytest-cov
     pyhamcrest
 


### PR DESCRIPTION
* Install `enum34` only for python older than 3.4 (because of [stoneleaf/enum34#5](https://bitbucket.org/stoneleaf/enum34/issues/5/enum34-incompatible-with-python-35))
* Bump `pytest` dependency to 2.7.3 (because of https://github.com/pytest-dev/pytest/issues/744)
* Bonus: Enable Travis container-based infrastructure :)