### PR TITLE
Fix doctests

### DIFF
--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -108,8 +108,14 @@ class AllureTestListener(object):
 
     @pytest.mark.hookwrapper
     def pytest_runtest_protocol(self, item, nextitem):
+        try:
+            # for common items
+            description = item.function.__doc__
+        except AttributeError:
+            # for doctests that has no `function` attribute
+            description = item.reportinfo()[2]
         self.test = TestCase(name='.'.join(mangle_testnames([x.name for x in parent_down_from_module(item)])),
-                             description=item.function.__doc__,
+                             description=description,
                              start=now(),
                              attachments=[],
                              labels=labels_of(item),

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from hamcrest import assert_that, contains, all_of, has_entry, has_property, has_properties
+
+
+def test_doctests(report_for):
+    report = report_for("""
+    def hello_world():
+        '''
+        >>> hello_world()
+        'hello world'
+        '''
+        return 'hello world'
+    """, ['--doctest-modules'])
+    assert_that(report.findall('.//test-case'), contains(
+        has_property('description', '[doctest] test_doctests.hello_world')))


### PR DESCRIPTION
When running `py.test --doctest-modules` allure always fails with internal error, because `DocTestItem` has no attribute `function`.

This change fixes it and makes simple description for doctest.