### PR TITLE
Do not accept pytest >2.9.0 during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = "1.7.1"
 
 install_requires = [
     "lxml>=3.2.0",
-    "pytest>=2.7.3",
+    "pytest>=2.7.3, <=2.9.0",
     "namedlist",
     "six>=1.9.0"
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = "1.7.1"
 
 install_requires = [
     "lxml>=3.2.0",
-    "pytest>=2.7.3, <=2.9.0",
+    "pytest>=2.7.3,<=2.9.0",
     "namedlist",
     "six>=1.9.0"
 ]


### PR DESCRIPTION
Pytest 2.9.1 breaks the allure-python plugin - until allure-python can accommodate for the changes to pytest, let's just require a version of pytest that will work with the current code.