### PR TITLE
fix test session finish with duplicated tests in suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
-python:
-  - '2.6'
-  - '2.7'
-  - '3.3'
-  - '3.4'
-  - '3.5'
+python: 3.5
 sudo: false
 env:
-  - TOX_ENV=py
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=static_check
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -436,6 +436,7 @@ class AllureHelper(object):
         else:
             raise AttributeError
 
+
 MASTER_HELPER = AllureHelper()
 
 

--- a/allure/pytest_plugin.py
+++ b/allure/pytest_plugin.py
@@ -480,7 +480,7 @@ class AllureAgregatingListener(object):
                     if t.id not in known_ids:
                         known_ids.add(t.id)
                         refined_tests.append(t)
-                s.tests[::-1] = refined_tests
+                s.tests = refined_tests[::-1]
 
                 with self.impl._reportfile('%s-testsuite.xml' % uuid.uuid4()) as f:
                     self.impl._write_xml(f, s)


### PR DESCRIPTION
For example fix situation when we repeat failed tests.
In this case `tests` and `refined_tests` have different size that will raise exception for tests[::-1] assignment.