### PR TITLE
Fix enum34 dependency for python versions > 3.4

### DIFF
--- a/allure-python-commons/setup.py
+++ b/allure-python-commons/setup.py
@@ -1,4 +1,3 @@
-import sys
 from setuptools import setup
 
 PACKAGE = "allure-python-commons"
@@ -15,11 +14,9 @@ classifiers = [
 install_requires = [
     "attrs>=16.0.0",
     "six>=1.9.0",
-    "pluggy>=0.4.0"
+    "pluggy>=0.4.0",
+    "enum34;python_version<'3.4'",
 ]
-
-if sys.version_info < (3, 4):
-    install_requires.append("enum34")
 
 
 def main():
@@ -38,6 +35,7 @@ def main():
         install_requires=install_requires,
         py_modules=['allure', 'allure_commons']
     )
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Added python_version environment marker for install_requires to fix situation when `allure-python-commons` dependency `enum34` was added to universal wheel file without proper handling of python version.

### Context
Currently, `enum34` dependency for `allure-python-commons` is added depending on python version of build system instead of python version of setup destination.

This issue can be reproduced by installation of `allure-pytest==2.2.3b1` from PyPi whl file on python 3.6. This will install `enum34` library for 3.6 system and cause internal python exceptions, like:
```Traceback (most recent call last):
  File "/opt/jenkins/shiningpanda/jobs/af2a4440/virtualenvs/d41d8cd9/bin/coverage", line 4, in <module>
    import re
  File "/opt/jenkins/shiningpanda/jobs/af2a4440/virtualenvs/d41d8cd9/lib/python3.6/re.py", line 142, in <module>
    class RegexFlag(enum.IntFlag):
AttributeError: module 'enum' has no attribute 'IntFlag'```
