### PR TITLE
add pcap MIME type for report attachments

### DIFF
--- a/allure-python-commons/src/types.py
+++ b/allure-python-commons/src/types.py
@@ -44,6 +44,7 @@ class AttachmentType(Enum):
     XML = ("application/xml", "xml")
     JSON = ("application/json", "json")
     YAML = ("application/yaml", "yaml")
+    PCAP = ("application/vnd.tcpdump.pcap", "pcap")
 
     PNG = ("image/png", "png")
     JPG = ("image/jpg", "jpg")


### PR DESCRIPTION
### Context

> I would like to be able to attach pcap logs to the allure report.

https://github.com/allure-framework/allure-python/issues/179

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
