### PR TITLE
Fix MIME type for HTML attachment

### DIFF
--- a/allure-python-commons/src/types.py
+++ b/allure-python-commons/src/types.py
@@ -40,7 +40,7 @@ class AttachmentType(Enum):
     TSV = ("text/tab-separated-values", "tsv")
     URI_LIST = ("text/uri-list", "uri")
 
-    HTML = ("application/html", "html")
+    HTML = ("text/html", "html")
     XML = ("application/xml", "xml")
     JSON = ("application/json", "json")
     YAML = ("application/yaml", "yaml")


### PR DESCRIPTION
### Context
MIME type for HTML attachment should comply with the type in front-end code:
https://github.com/allure-framework/allure2/blob/master/allure-generator/src/main/javascript/utils/attachmentType.js#L36
```javascript
        case 'text/html':
            return {
                type: 'html',
                icon: 'fa fa-file-code-o',
            };
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
