### PR TITLE
Add log option to allure-pytest, implemented as a step.

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -32,6 +32,12 @@ class AllureListener(object):
         self._thread = thread_tag()
 
     @allure_commons.hookimpl
+    def log(self, uuid, msg):
+        # mimics logs using an empty step
+        self.start_step(uuid, msg, [])
+        self.stop_step(uuid, None, None, None)
+
+    @allure_commons.hookimpl
     def start_step(self, uuid, title, params):
         parameters = [Parameter(name=name, value=value) for name, value in params]
         step = TestStepResult(name=title, start=now(), parameters=parameters)

--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -1,10 +1,12 @@
 import argparse
+import logging
 
 import allure
 import allure_commons
 
 from allure_commons.types import LabelType
 from allure_commons.logger import AllureFileLogger
+from allure_commons.cli_logger import AllureLoggingHandler
 
 from allure_pytest.utils import allure_labels
 from allure_pytest.helper import AllureTestHelper
@@ -118,6 +120,7 @@ def pytest_configure(config):
         file_logger = AllureFileLogger(report_dir, clean)
         allure_commons.plugin_manager.register(file_logger)
         config.add_cleanup(cleanup_factory(file_logger))
+        logging.getLogger().addHandler(AllureLoggingHandler())
 
 
 def pytest_collection_modifyitems(items, config):

--- a/allure-pytest/test/cli_logging/test_cli_logs.py
+++ b/allure-pytest/test/cli_logging/test_cli_logs.py
@@ -1,0 +1,34 @@
+import pytest
+import logging
+
+
+logger = logging.getLogger(__name__)
+logger.info("Log outside test should not break, only be ignored")
+
+
+@pytest.fixture
+def fixture_with_log():
+    logger.info("Log in fixture setup")
+    yield
+    logger.info("Log in fixture teardown")
+
+
+def test_logs(fixture_with_log):
+    """
+    >>> from allure_commons.utils import represent
+    >>> allure_report = getfixture('allure_report_with_params')('--log-cli-level=INFO')
+    >>> assert_that(allure_report,
+    ...             has_test_case('test_logs',
+    ...                           has_step(contains_string('Log inside test')),
+    ...                           has_container(allure_report,
+    ...                                         has_before('fixture_with_log',
+    ...                                                    has_step(contains_string('Log in fixture setup'))
+    ...                                         ),
+    ...                                         has_after('fixture_with_log::teardown',
+    ...                                                   has_step(contains_string('Log in fixture teardown'))
+    ...                                         )
+    ...                           )
+    ...             )
+    ... )
+    """
+    logger.info("Log inside test")

--- a/allure-python-commons-test/src/result.py
+++ b/allure-python-commons-test/src/result.py
@@ -81,10 +81,15 @@ def has_description_html(*matchers):
 
 
 def has_step(name, *matchers):
+    if isinstance(name, str):
+        match_name = equal_to(name)
+    else:
+        match_name = name
+
     return has_entry('steps',
                      has_item(
                          all_of(
-                             has_entry('name', equal_to(name)),
+                             has_entry('name', match_name),
                              *matchers
                          )
                      ))

--- a/allure-python-commons/allure.py
+++ b/allure-python-commons/allure.py
@@ -7,6 +7,7 @@ from allure_commons._allure import epic, feature, story
 from allure_commons._allure import link, issue, testcase
 from allure_commons._allure import Dynamic as dynamic
 from allure_commons._allure import step
+from allure_commons._allure import log
 from allure_commons._allure import attach
 from allure_commons.types import Severity as severity_level
 from allure_commons.types import AttachmentType as attachment_type
@@ -28,6 +29,7 @@ __all__ = [
     'testcase',
 
     'step',
+    'log',
 
     'dynamic',
 

--- a/allure-python-commons/src/__init__.py
+++ b/allure-python-commons/src/__init__.py
@@ -2,6 +2,7 @@ from allure_commons._hooks import hookimpl  # noqa: F401
 from allure_commons._core import plugin_manager  # noqa: F401
 from allure_commons._allure import fixture  # noqa: F401
 from allure_commons._allure import test  # noqa: F401
+from allure_commons._allure import log
 
 
 __all__ = [
@@ -9,5 +10,7 @@ __all__ = [
     'plugin_manager',
 
     'fixture',
-    'test'
+    'test',
+
+    'log',
 ]

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -117,6 +117,10 @@ def step(title):
         return StepContext(title, ({}, {}))
 
 
+def log(msg):
+    plugin_manager.hook.log(uuid=uuid4(), msg=msg)
+
+
 class StepContext:
 
     def __init__(self, title, params):

--- a/allure-python-commons/src/_hooks.py
+++ b/allure-python-commons/src/_hooks.py
@@ -47,6 +47,10 @@ class AllureUserHooks(object):
         """ url """
 
     @hookspec
+    def log(self, uuid, msg):
+        """ log """
+
+    @hookspec
     def start_step(self, uuid, title, params):
         """ step """
 

--- a/allure-python-commons/src/cli_logger.py
+++ b/allure-python-commons/src/cli_logger.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+import logging
+import allure_commons
+
+
+class AllureLoggingHandler(logging.Handler):
+    def emit(self, record):
+        allure_commons.log("[Log]   {} ({}, {})".format(record.getMessage(), record.levelname, record.name))


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Allure-framework does not have natively the concept of logs. They are however important information that users would want to add to the report.

This PR creates a new feature for logs for allure-pytest:
- A hook specification
- The log hook implementation in `listener.py`, which creates a step
- A function accessible in allure namespace (`allure.log`), which calls the log hook
- A logging Handler on the root logger that catches logs from logging and calls `allure.log` with a `[Log]` prefix.

This solution is flexible enough to treat other cases when we want to add a record to the report. For instance, we could create a function that could capture stdout and call `allure.log` with a `[print]` prefix.

This could be added without any changes to allure core code by just creating an empty step. However, internally we have some tools that would greatly benefit from separate concepts: We have a third-party plugins that implements the allure hooks `start/stop step` and `log` and treat them differently, as they really are.

I know this change could be somehow controversial but we hope we can discuss around this feature.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
