### PR TITLE
Add option to flatten a step.

### DIFF
--- a/allure-pytest/test/steps/flattening/test_steps_flattening.py
+++ b/allure-pytest/test/steps/flattening/test_steps_flattening.py
@@ -1,0 +1,56 @@
+import allure
+
+
+@allure.step("Function 1 has custom name")
+def function1(a,b,c):
+    pass
+
+
+@allure.step
+def function2(a,b,c):
+    function1(1,2,3)
+
+
+@allure.step(flatten=True)
+def function3(a,b,c):
+    function1(4,5,6)
+    function2(7,8,9)
+
+
+def test_flattened_steps():
+    """
+    >>> from allure_commons.utils import represent
+    >>> allure_report = getfixture('allure_report')
+    >>> assert_that(allure_report,
+    ...             has_test_case('test_flattened_steps',
+    ...                           has_step('First step',
+    ...                                    has_step('Function 1 has custom name'),
+    ...                                    has_step('function2',
+    ...                                             has_step('Function 1 has custom name')
+    ...                                    ),
+    ...                                    has_step('function3',
+    ...                                             not_( has_step('Function 1 has custom name') ),
+    ...                                             not_( has_step('function2') ),
+    ...                                    )
+    ...                           ),
+    ...                           has_step('Second step',
+    ...                                    not_( has_step('Function 1 has custom name') ),
+    ...                                    not_( has_step('function2') ),
+    ...                                    has_step('Third step',
+    ...                                             not_( has_step('function3') ),
+    ...                                    ),
+    ...                           )
+    ...             )
+    ... )
+    """
+    with allure.step("First step"):
+        function1(1,1,1)
+        function2(2,2,2)
+        function3(3,3,3)
+
+    with allure.step("Second step", flatten=True):
+        function1(4,4,4)
+        function2(5,5,5)
+
+        with allure.step("Third step", force=True):
+            function3(6,6,6)


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Sometimes we define a custom function as a step, and this function uses other functions that would also be a step, and so on.
Therefore, sometimes it can be unnecessary to show this internal function calls as steps too, as it would pollute the test report.

This PR adds to the `allure.step` function:

- An argument called `flatten`. If true, then no further steps are created until this function returns.
- An argument called `force`, in case there is a step we always want to show in the report regardless of any higher level step with `flatten`.

RobotFramework has a similar feature but command-line only:
http://robotframework.org/robotframework/2.9b2/RobotFrameworkUserGuide.html#flattening-keywords

We could later on also add command-line options for run-time definition of step names to be flattened.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
