### PR TITLE
Close pytest test from pytest_runtest_logfinish hook (fixes #360)

### DIFF
--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 install_requires = [
-    "pytest>=3.3.0",
+    "pytest>=3.4.0",
     "six>=1.9.0",
     "allure-python-commons==2.6.0"
 ]

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -199,8 +199,11 @@ class AllureListener(object):
                 self.attach_data(report.capstdout, "stdout", AttachmentType.TEXT, None)
                 self.attach_data(report.capstderr, "stderr", AttachmentType.TEXT, None)
 
-            uuid = self._cache.pop(item.nodeid)
-            self.allure_logger.close_test(uuid)
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_logfinish(self, nodeid, location):
+        yield
+        uuid = self._cache.pop(nodeid)
+        self.allure_logger.close_test(uuid)
 
     @allure_commons.hookimpl
     def attach_data(self, body, name, attachment_type, extension):

--- a/allure-pytest/test/acceptance/attachment/attachment_hook_test.py
+++ b/allure-pytest/test/acceptance/attachment/attachment_hook_test.py
@@ -1,0 +1,49 @@
+from hamcrest import assert_that
+from allure_commons_test.report import has_test_case
+from allure_commons_test.result import has_attachment
+
+
+def test_attach_from_runtest_teardown(allured_testdir):
+    allured_testdir.testdir.makeconftest("""
+        import allure
+
+
+        def pytest_runtest_teardown(*args, **kwargs):
+            allure.attach(body="body", name="attachment from teardown")
+    """)
+
+    allured_testdir.testdir.makepyfile("""
+        def test_attach_from_runtest_teardown():
+            pass
+    """)
+
+    allured_testdir.run_with_allure()
+
+    assert_that(allured_testdir.allure_report,
+                has_test_case("test_attach_from_runtest_teardown",
+                              has_attachment(name="attachment from teardown"),
+                              )
+                )
+
+
+def test_attach_from_runtest_logfinish(allured_testdir):
+    allured_testdir.testdir.makeconftest("""
+        import allure
+
+
+        def pytest_runtest_logfinish(*args, **kwargs):
+            allure.attach(body="body", name="attachment from logfinish")
+    """)
+
+    allured_testdir.testdir.makepyfile("""
+        def test_attach_from_runtest_logfinish():
+            pass
+    """)
+
+    allured_testdir.run_with_allure()
+
+    assert_that(allured_testdir.allure_report,
+                has_test_case("test_attach_from_runtest_logfinish",
+                              has_attachment(name="attachment from logfinish"),
+                              )
+                )


### PR DESCRIPTION
### Context
Moved closing of a test from pytest_runtest_makereport to pytest_runtest_logfinish according to changes in pytest framework.
Updated required pytest version from 3.3.0 to 3.4.0 where the hook was introduced.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
