### PR TITLE
name equals to url if name is not passed

### DIFF
--- a/allure-pytest/src/helper.py
+++ b/allure-pytest/src/helper.py
@@ -44,4 +44,5 @@ class AllureTestHelper(object):
         pattern = dict(self.config.option.allure_link_pattern).get(link_type, u'{}')
         url = pattern.format(url)
         allure_link = getattr(pytest.mark, allure_link_marker)
+        name = url if name is None else name
         return allure_link(url, name=name, link_type=link_type)


### PR DESCRIPTION
The reason for this addition is that now this place doen't match the documentation and expected behavior.

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
