### PR TITLE
Support for Allure links in RobotFramework integration

### DIFF
--- a/allure-robotframework/examples/link/link.rst
+++ b/allure-robotframework/examples/link/link.rst
@@ -40,7 +40,15 @@ Ordinary links are supported via tags prefixed with :code:`link:` :
 .. code:: robotframework
 
     *** Test Cases ***
-    Test Case With Link
+    Test Case With Unnamed Link
+        [Tags]  link:https://homepage.com/
+        No Operation
+
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    Test Case With Named Link
         [Tags]  link:[Home Page]https://homepage.com/
         No Operation
 

--- a/allure-robotframework/examples/link/link.rst
+++ b/allure-robotframework/examples/link/link.rst
@@ -1,0 +1,47 @@
+Links
+-----
+
+Issues are supported via tags prefixed with :code:`issue:` :
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    Test Case With Issue Link Without URL
+        [Tags]  issue:ISSUE-1
+        No Operation
+
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    Test Case With Issue Link With URL
+        [Tags]  issue:https://jira.com/browse/ISSUE-1
+        No Operation
+
+TMS links are supported via tags prefixed with :code:`test_case:` :
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    Test Case With TMS Link Without URL
+        [Tags]  test_case:TEST-1
+        No Operation
+
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    Test Case With TMS Link With URL
+        [Tags]  test_case:https://testrail.com/browse/TEST-1
+        No Operation
+
+Ordinary links are supported via tags prefixed with :code:`link:` :
+
+.. code:: robotframework
+
+    *** Test Cases ***
+    Test Case With Link
+        [Tags]  link:[Home Page]https://homepage.com/
+        No Operation
+
+allure will track it and show actual tags set.

--- a/allure-robotframework/examples/link/link.rst
+++ b/allure-robotframework/examples/link/link.rst
@@ -40,16 +40,15 @@ Ordinary links are supported via tags prefixed with :code:`link:` :
 .. code:: robotframework
 
     *** Test Cases ***
-    Test Case With Unnamed Link
+    Test Case With Unlabeled Link
         [Tags]  link:https://homepage.com/
         No Operation
 
+Link label can be specified by text placed in :code:`[square brackets]` :
 
 .. code:: robotframework
 
     *** Test Cases ***
-    Test Case With Named Link
+    Test Case With Labeled Link
         [Tags]  link:[Home Page]https://homepage.com/
         No Operation
-
-allure will track it and show actual tags set.

--- a/allure-robotframework/src/listener/robot_listener.py
+++ b/allure-robotframework/src/listener/robot_listener.py
@@ -111,11 +111,10 @@ class allure_robotframework(object):
         test.labels.extend(utils.get_allure_suites(attributes.get('longname')))
 
         test.labels.extend(allure_tags(attributes))
-        test.labels.extend(allure_labels(attributes, LabelType.EPIC))
-        test.labels.extend(allure_labels(attributes, LabelType.FEATURE))
-        test.labels.extend(allure_labels(attributes, LabelType.STORY))
-        test.links.extend(allure_links(attributes, LinkType.ISSUE))
-        test.links.extend(allure_links(attributes, LinkType.TEST_CASE))
+        for label_type in (LabelType.EPIC, LabelType.FEATURE, LabelType.STORY):
+            test.labels.extend(allure_labels(attributes, label_type))
+        for link_type in (LinkType.ISSUE, LinkType.TEST_CASE, LinkType.LINK):
+            test.links.extend(allure_links(attributes, link_type))
         test.labels.append(Label(name=LabelType.THREAD, value=self.pool_id))
         test.labels.append(Label(name=LabelType.HOST, value=host_tag()))
         test.labels.append(Label(name=LabelType.FRAMEWORK, value='robotframework'))

--- a/allure-robotframework/src/listener/robot_listener.py
+++ b/allure-robotframework/src/listener/robot_listener.py
@@ -17,7 +17,7 @@ from allure_robotframework.types import RobotKeywordType, RobotLogLevel
 from allure_robotframework import utils
 from allure_robotframework.allure_listener import AllureListener
 
-from allure_robotframework.utils import allure_tags, allure_labels
+from allure_robotframework.utils import allure_tags, allure_labels, allure_links
 
 
 # noinspection PyPep8Naming
@@ -114,7 +114,8 @@ class allure_robotframework(object):
         test.labels.extend(allure_labels(attributes, LabelType.EPIC))
         test.labels.extend(allure_labels(attributes, LabelType.FEATURE))
         test.labels.extend(allure_labels(attributes, LabelType.STORY))
-
+        test.links.extend(allure_links(attributes, LinkType.ISSUE))
+        test.links.extend(allure_links(attributes, LinkType.TEST_CASE))
         test.labels.append(Label(name=LabelType.THREAD, value=self.pool_id))
         test.labels.append(Label(name=LabelType.HOST, value=host_tag()))
         test.labels.append(Label(name=LabelType.FRAMEWORK, value='robotframework'))

--- a/allure-robotframework/src/listener/utils.py
+++ b/allure-robotframework/src/listener/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from re import search
 from allure_commons.model2 import Status, Label, Parameter, Link
 from allure_commons.types import LabelType
 from allure_robotframework.types import RobotStatus
@@ -52,10 +53,20 @@ def allure_labels(attributes, prefix):
 def allure_links(attributes, prefix):
     tags = attributes.get('tags', ())
 
-    def is_label(label):
-        return label.startswith("{label}:".format(label=prefix))
+    def is_link(link):
+        return link.startswith("{link}:".format(link=prefix))
 
-    def label_value(label):
-        return label.split(':', 1)[1] or 'unknown'
+    def parse_link(link):
+        lnk_val = link.split(':', 1)[1] or 'unknown'
+        lnk_label = search(r'\[.+\]', lnk_val)
+        if lnk_label:
+            lnk_label = lnk_label.group(0)
+            lnk_val = lnk_val.strip(lnk_label)
+            lnk_label = lnk_label.strip('[]')
+        else:
+            lnk_label = lnk_val
 
-    return [Link(type=prefix, url=label_value(tag), name=label_value(tag)) for tag in tags if is_label(tag)]
+        return {'name': lnk_label, 'value': lnk_val}
+
+    return [Link(type=prefix, url=parse_link(tag).get('value'), name=parse_link(tag).get('name')) for tag in tags if
+            is_link(tag)]

--- a/allure-robotframework/src/listener/utils.py
+++ b/allure-robotframework/src/listener/utils.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from allure_commons.model2 import Status, Label, Parameter
+from allure_commons.model2 import Status, Label, Parameter, Link
 from allure_commons.types import LabelType
 from allure_robotframework.types import RobotStatus
 
@@ -47,3 +47,15 @@ def allure_labels(attributes, prefix):
         return label.split(':')[1] or 'unknown'
 
     return [Label(name=prefix, value=label_value(tag)) for tag in tags if is_label(tag)]
+
+
+def allure_links(attributes, prefix):
+    tags = attributes.get('tags', ())
+
+    def is_label(label):
+        return label.startswith("{label}:".format(label=prefix))
+
+    def label_value(label):
+        return label.split(':', 1)[1] or 'unknown'
+
+    return [Link(type=prefix, url=label_value(tag), name=label_value(tag)) for tag in tags if is_label(tag)]

--- a/allure-robotframework/test/link/link.robot
+++ b/allure-robotframework/test/link/link.robot
@@ -27,6 +27,11 @@ Test Case With TMS Link With URL
     ${test_case}     Should Has Test Case   ${report}   Test Case With TMS Link With URL
     Should Has Link  ${test_case}  https://testrail.com/browse/TEST-1  test_case
 
-Test Case With Link
-    ${test_case}     Should Has Test Case   ${report}   Test Case With Link
+Test Case With Unnamed Link
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Unnamed Link
+    Should Has Link  ${test_case}  https://homepage.com/  link
+
+Test Case With Named Link
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Named Link
+    Should Has Link  ${test_case}  https://homepage.com/  link  Home Page
 

--- a/allure-robotframework/test/link/link.robot
+++ b/allure-robotframework/test/link/link.robot
@@ -27,11 +27,11 @@ Test Case With TMS Link With URL
     ${test_case}     Should Has Test Case   ${report}   Test Case With TMS Link With URL
     Should Has Link  ${test_case}  https://testrail.com/browse/TEST-1  test_case
 
-Test Case With Unnamed Link
-    ${test_case}     Should Has Test Case   ${report}   Test Case With Unnamed Link
+Test Case With Unlabeled Link
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Unlabeled Link
     Should Has Link  ${test_case}  https://homepage.com/  link
 
-Test Case With Named Link
-    ${test_case}     Should Has Test Case   ${report}   Test Case With Named Link
+Test Case With Labeled Link
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Labeled Link
     Should Has Link  ${test_case}  https://homepage.com/  link  Home Page
 

--- a/allure-robotframework/test/link/link.robot
+++ b/allure-robotframework/test/link/link.robot
@@ -1,0 +1,32 @@
+*** Settings ***
+Library     ../run_robot_library.py
+Library     ../test_allure_library.py
+Suite Setup  Run example
+
+
+*** Keywords ***
+Run example
+    ${allure_report}   Run Robot With Allure   examples/link/link.rst
+    Set Suite Variable	${report}   ${allure_report}
+
+
+*** Test Case ***
+Test Case With Issue Link Without URL
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Issue Link Without URL
+    Should Has Link  ${test_case}  ISSUE-1  issue
+
+Test Case With Issue Link With URL
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Issue Link With URL
+    Should Has Link  ${test_case}  https://jira.com/browse/ISSUE-1  issue
+
+Test Case With TMS Link Without URL
+    ${test_case}     Should Has Test Case   ${report}   Test Case With TMS Link Without URL
+    Should Has Link  ${test_case}  TEST-1  test_case
+
+Test Case With TMS Link With URL
+    ${test_case}     Should Has Test Case   ${report}   Test Case With TMS Link With URL
+    Should Has Link  ${test_case}  https://testrail.com/browse/TEST-1  test_case
+
+Test Case With Link
+    ${test_case}     Should Has Test Case   ${report}   Test Case With Link
+


### PR DESCRIPTION
### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
* Added support for `test_case`, `issue` and `link` report links.
* Links are provided via Robot `[Tags]`
* Ordinary `link` can be provided with optional name placed in square brackets. 


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
