### PR TITLE
Add trove classifiers for supported python versions

### DIFF
--- a/allure-behave/setup.py
+++ b/allure-behave/setup.py
@@ -10,7 +10,12 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
-    'Topic :: Software Development :: Testing :: BDD'
+    'Topic :: Software Development :: Testing :: BDD',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 install_requires = [


### PR DESCRIPTION
### Context

This marks the project as working on Python 2 and 3. As tests currently run on python 2.7, 3.6 and 3.7, I've added those classifiers specifically.

I am working on migrating a project to Python 3, and this might save the next person a few clicks when finding out if this library supports it.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
