### PR TITLE
Ability to mark step as failed

### DIFF
--- a/allure-pytest/examples/step/step.rst
+++ b/allure-pytest/examples/step/step.rst
@@ -10,6 +10,11 @@ Steps
     ...         pass
 
 
+    >>> def test_inline_fail_mark_step():
+    ...     with allure.step("inline fail mark step") as step:
+    ...         step.fail_mark = "some fail message"
+
+
     >>> @allure.step
     ... def passed_step():
     ...     pass

--- a/allure-pytest/examples/step/step.rst
+++ b/allure-pytest/examples/step/step.rst
@@ -12,7 +12,8 @@ Steps
 
     >>> def test_inline_fail_mark_step():
     ...     with allure.step("inline fail mark step") as step:
-    ...         step.fail_mark = "some fail message"
+    ...         step.status = "failed"
+    ...         step.message = "some fail message"
 
 
     >>> @allure.step

--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -5,7 +5,7 @@ import six
 import pytest
 from itertools import chain, islice
 from allure_commons.utils import represent
-from allure_commons.utils import format_exception, format_traceback, escape_non_unicode_symbols
+from allure_commons.utils import format_exception, format_traceback, escape_non_unicode_symbols, StepFailMark
 from allure_commons.model2 import Status
 from allure_commons.model2 import StatusDetails
 from allure_commons.types import LabelType
@@ -152,7 +152,9 @@ def get_status(exception):
     if exception:
         if isinstance(exception, AssertionError) or isinstance(exception, pytest.fail.Exception):
             return Status.FAILED
-        elif isinstance(exception, pytest.skip.Exception):
+        if isinstance(exception, StepFailMark):
+            return Status.FAILED
+        if isinstance(exception, pytest.skip.Exception):
             return Status.SKIPPED
         return Status.BROKEN
     else:

--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -5,7 +5,14 @@ import six
 import pytest
 from itertools import chain, islice
 from allure_commons.utils import represent
-from allure_commons.utils import format_exception, format_traceback, escape_non_unicode_symbols, StepFailMark
+from allure_commons.utils import (
+    format_exception,
+    format_traceback,
+    escape_non_unicode_symbols,
+    StepBrokenMark,
+    StepFailMark,
+    StepPassedMark,
+)
 from allure_commons.model2 import Status
 from allure_commons.model2 import StatusDetails
 from allure_commons.types import LabelType
@@ -152,10 +159,14 @@ def get_status(exception):
     if exception:
         if isinstance(exception, AssertionError) or isinstance(exception, pytest.fail.Exception):
             return Status.FAILED
-        if isinstance(exception, StepFailMark):
-            return Status.FAILED
         if isinstance(exception, pytest.skip.Exception):
             return Status.SKIPPED
+        if isinstance(exception, StepFailMark):
+            return Status.FAILED
+        if isinstance(exception, StepBrokenMark):
+            return Status.BROKEN
+        if isinstance(exception, StepPassedMark):
+            return Status.PASSED
         return Status.BROKEN
     else:
         return Status.PASSED

--- a/allure-python-commons/src/utils.py
+++ b/allure-python-commons/src/utils.py
@@ -387,3 +387,7 @@ def format_exception(etype, value):
     "AssertionError: \\nExpected:...but:..."
     """
     return '\n'.join(format_exception_only(etype, value)) if etype or value else None
+
+
+class StepFailMark(Exception):
+    pass

--- a/allure-python-commons/src/utils.py
+++ b/allure-python-commons/src/utils.py
@@ -391,3 +391,11 @@ def format_exception(etype, value):
 
 class StepFailMark(Exception):
     pass
+
+
+class StepBrokenMark(Exception):
+    pass
+
+
+class StepPassedMark(Exception):
+    pass


### PR DESCRIPTION
Hi there. In this pr realize step fail mark.

My tests use soft asserts, its mean some check not raise exceptions right now. Error message its saved and raises in test end.
But with this approach there is a problem with displaying step status.

This pr can solved this problem.
![76bbb4ee6a](https://user-images.githubusercontent.com/26869885/62466773-d0f3dc80-b79a-11e9-97e3-e292554429b5.png)
1) Error find in this step
2) All checks in this step