### PR TITLE
Exclude duplicate links in report

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -239,8 +239,8 @@ class AllureListener(object):
         test_result = self.allure_logger.get_test(None)
         if test_result:
             pattern = dict(self.config.option.allure_link_pattern).get(link_type, u'{}')
-            url = pattern.format(url)
-            new_link = Link(link_type, url, name)
+            link_url = pattern.format(url)
+            new_link = Link(link_type, link_url, link_url if name is None else name)
             for link in test_result.links:
                 if link.url == new_link.url:
                     return

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -240,7 +240,11 @@ class AllureListener(object):
         if test_result:
             pattern = dict(self.config.option.allure_link_pattern).get(link_type, u'{}')
             url = pattern.format(url)
-            test_result.links.append(Link(link_type, url, name))
+            new_link = Link(link_type, url, name)
+            for link in test_result.links:
+                if link.url == new_link.url:
+                    return
+            test_result.links.append(new_link)
 
     @allure_commons.hookimpl
     def add_label(self, label_type, labels):

--- a/allure-pytest/test/acceptance/link/dynamic_link_test.py
+++ b/allure-pytest/test/acceptance/link/dynamic_link_test.py
@@ -1,7 +1,7 @@
 """ ./examples/link/dynamic_link.rst """
 
 import pytest
-from hamcrest import assert_that
+from hamcrest import assert_that, equal_to
 from allure_commons_test.report import has_test_case
 from allure_commons_test.result import has_link
 from allure_commons_test.result import has_issue_link
@@ -28,7 +28,19 @@ def test_all_links_together(executed_docstring_path):
     assert_that(executed_docstring_path.allure_report,
                 has_test_case("test_all_links_together",
                               has_issue_link("issues/24"),
-                              has_issue_link("issues/24"),
+                              has_issue_link("issues/132"),
                               has_link("allure", name="QAMETA", link_type="docs")
                               )
                 )
+
+
+def test_unique_dynamic_links(executed_docstring_source):
+    """
+    >>> import allure
+
+    >>> def test_unique_dynamic_links_example():
+    ...     allure.dynamic.link("some/unique/dynamic/link")
+    ...     allure.dynamic.link("some/unique/dynamic/link")
+    """
+    assert_that(executed_docstring_source.allure_report.test_cases[0]['links'],
+                equal_to([{'url': u'some/unique/dynamic/link', 'type': 'link', 'name': u'some/unique/dynamic/link'}]))

--- a/allure-python-commons-test/src/result.py
+++ b/allure-python-commons-test/src/result.py
@@ -159,4 +159,3 @@ def with_trace_contains(string):
 
 def has_history_id():
     return has_entry('historyId', anything())
-


### PR DESCRIPTION
On some cases i need go to pages several time. But attach links method locate in "go_to_page" function, and i get something like this
![87a30bb62d](https://user-images.githubusercontent.com/26869885/63531266-d417f800-c510-11e9-820a-aedac51a865f.png)

I suggest to check links for prevent add duplicates
