### PR TITLE
Adding patch for error AttributeError: 'NoneType' object has no attri…

### DIFF
--- a/allure-python-commons/src/reporter.py
+++ b/allure-python-commons/src/reporter.py
@@ -57,8 +57,11 @@ class AllureReporter(object):
         self._items.pop(uuid)
 
     def start_after_fixture(self, parent_uuid, uuid, fixture):
-        self._items.get(parent_uuid).afters.append(fixture)
-        self._items[uuid] = fixture
+        try:
+            self._items.get(parent_uuid).afters.append(fixture)
+            self._items[uuid] = fixture
+        except:
+            self._items[uuid] = fixture
 
     def stop_after_fixture(self, uuid, **kwargs):
         self._update_item(uuid, **kwargs)


### PR DESCRIPTION
…bute 'afters' (fixes #216)

Issue occurs when using allure-python with pytest-selenium
when passing the selenium argument (as main driver according to pytest-selenium library)
