### PR TITLE
fix for 'allure-pytest-bdd' report marks feature as 'Fail' even when all steps pass

### DIFF
--- a/allure-pytest-bdd/src/pytest_bdd_listener.py
+++ b/allure-pytest-bdd/src/pytest_bdd_listener.py
@@ -9,8 +9,9 @@ from allure_commons.utils import host_tag, thread_tag
 from .utils import get_uuid
 from .utils import get_step_name
 from .utils import get_status_details
+from .utils import get_pytest_report_status
 from allure_commons.model2 import StatusDetails
-from functools import partial, reduce
+from functools import partial
 from allure_commons.lifecycle import AllureLifecycle
 from .utils import get_full_name
 
@@ -84,8 +85,7 @@ class PytestBDDListener(object):
     def pytest_runtest_makereport(self, item, call):
         report = (yield).get_result()
 
-        status = reduce(lambda final_status, current_status: final_status or getattr(report, current_status, None),
-                        ["failed", "passed", "skipped"])
+        status = get_pytest_report_status(report)
 
         status_details = StatusDetails(
             message=call.excinfo.exconly(),

--- a/allure-pytest-bdd/src/utils.py
+++ b/allure-pytest-bdd/src/utils.py
@@ -2,6 +2,7 @@ import os
 from uuid import UUID
 from allure_commons.utils import md5
 from allure_commons.model2 import StatusDetails
+from allure_commons.model2 import Status
 from allure_commons.utils import format_exception
 
 
@@ -22,3 +23,11 @@ def get_status_details(exception):
     message = str(exception)
     trace = format_exception(type(exception), exception)
     return StatusDetails(message=message, trace=trace) if message or trace else None
+
+
+def get_pytest_report_status(pytest_report):
+    pytest_statuses = ('failed', 'passed', 'skipped')
+    statuses = (Status.FAILED, Status.PASSED, Status.SKIPPED)
+    for pytest_status, status in zip(pytest_statuses, statuses):
+        if getattr(pytest_report, pytest_status):
+            return status


### PR DESCRIPTION
Fix for 'allure-pytest-bdd' report marks feature as 'Fail' even when all steps pass when test is using 'Scenario Outline' #455