### PR TITLE
Use user-data to pass link patterns to Allure-Behave

### DIFF
--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -97,7 +97,9 @@ class AllureListener(object):
         test_case.description = '\n'.join(scenario.description)
         test_case.parameters = scenario_parameters(scenario)
 
-        test_case.links.extend(scenario_links(scenario))
+        issue_pattern = self.behave_config.userdata.get('AllureFormatter.issue_pattern', None)
+        link_pattern = self.behave_config.userdata.get('AllureFormatter.link_pattern', None)
+        test_case.links.extend(scenario_links(scenario, issue_pattern=issue_pattern, link_pattern=link_pattern))
         test_case.labels.extend(scenario_labels(scenario))
         test_case.labels.append(Label(name=LabelType.FEATURE, value=scenario.feature.name))
         test_case.labels.append(Label(name=LabelType.FRAMEWORK, value='behave'))

--- a/allure-behave/src/utils.py
+++ b/allure-behave/src/utils.py
@@ -38,9 +38,12 @@ def scenario_parameters(scenario):
     return [Parameter(name=name, value=value) for name, value in zip(row.headings, row.cells)] if row else None
 
 
-def scenario_links(scenario):
+def scenario_links(scenario, issue_pattern, link_pattern):
     tags = scenario.feature.tags + scenario.tags
-    parsed = [parse_tag(item) for item in tags]
+    parsed = [
+        parse_tag(item, issue_pattern=issue_pattern, link_pattern=link_pattern)
+        for item in tags
+    ]
     return filter(lambda x: isinstance(x, Link), parsed)
 
 

--- a/allure-python-commons/src/mapping.py
+++ b/allure-python-commons/src/mapping.py
@@ -13,7 +13,7 @@ def __is(kind, t):
     return kind in [v for k, v in t.__dict__.items() if not k.startswith('__')]
 
 
-def parse_tag(tag):
+def parse_tag(tag, *, issue_pattern=None, link_pattern=None):
     """
     >>> parse_tag("blocker")
     Label(name='severity', value='blocker')
@@ -48,6 +48,10 @@ def parse_tag(tag):
     if prefix == TAG_PREFIX and value is not None:
 
         if __is(kind, LinkType):
+            if issue_pattern and kind == "issue" and not value.startswith("http"):
+                value = issue_pattern.format(value)
+            if link_pattern and kind == "link" and not value.startswith("http"):
+                value = issue_pattern.format(value)
             return Link(type=kind, name=name or value, url=value)
 
         if __is(kind, LabelType):


### PR DESCRIPTION
#### I'm submitting a ... 
  - [ ] bug report
  - [x] feature request
  - [ ] support request => Please do not submit support request here, see note at the top of this template.

#### What is the current behavior?

At the moment the only way (that I'm aware of) to link a scenario to a TMS or Issue Tracking system in `allure-python` is to use specialised scenario tags which contain the whole URL to the ticket/issue, e.g.: 
```gherkin
@allure.link:http://tms.system.com/ticket-55
@allure.issue:http://bug.tracking.com/BUG-42
Scenario: Annotated with links to TMS and Issue Tracker
...
```
 
More on that in the source code https://github.com/allure-framework/allure-python/blob/master/allure-python-commons/src/mapping.py#L21

This works, but it:
* adds extra repetitive work by forcing users to always include the whole link to a ticket/bug
* exposes potentially sensitive information about location of an Issue or TMS tracking systems (not all people or teams can reveal such information)

`allure-java` allows users to define link patterns to such systems. They're nicely documented in here https://docs.qameta.io/allure/#_links


#### What is the expected behavior?

Allow Python users to define link patterns to a TMS and Issue tracking systems so that Allure can replace `{}` placeholders with value specified in appropriate tag (`@allure.link` & `@allure.issue` respectively. 
PS. Maybe these tags could be even shortened to just `link` & `issue`?).

It'd be amazing if we'd be able to specify those link patterns as environmental variable, or as an additional parameter passed to Behave's Allure formatter, just like it's done in `pytest` using dynamic links and `--allure-link-pattern` parameter:
* https://github.com/allure-framework/allure-python/blob/master/allure-pytest/examples/link/dynamic_link.rst
* https://github.com/allure-framework/allure-python/blob/master/allure-pytest/test/acceptance/link/link_pattern_test.py#L11

#### What is the motivation / use case for changing the behavior?

* reduce time required to maintain the test suite
* give Allure users greater flexibility in regard to report customisation
* reduce the risk of exposing potentially sensitive information

#### Please tell us about your environment:

- Allure version: 2.13.1
- Test framework: behave@1.2.6
- Allure adaptor: allure-behave@2.8.9
- Python: 3.8

#### Other information 

* Giiter chat where I discussed the issue with Dmitry Baev:
https://gitter.im/allure-framework/allure-core?at=5e3c2f6ffe0e6f74e906c58e