### PR TITLE
Fix behave hooks by adding Configuration object instead of dict

### DIFF
--- a/allure-behave/src/hooks.py
+++ b/allure-behave/src/hooks.py
@@ -3,6 +3,7 @@ import threading
 import allure_commons
 from allure_commons.logger import AllureFileLogger
 from allure_behave.listener import AllureListener
+from behave.configuration import Configuration
 
 HOOKS = [
     "before_feature",
@@ -40,7 +41,7 @@ def allure_report(result_dir="allure_results"):
 
 class AllureHooks(object):
     def __init__(self, result_dir):
-        self.listener = AllureListener({})
+        self.listener = AllureListener(Configuration())
 
         if not hasattr(_storage, 'file_logger'):
             _storage.file_logger = AllureFileLogger(result_dir)


### PR DESCRIPTION
### Context
When I use the `allure_report` hook, I got these errors:
```
HOOK-ERROR in before_scenario: AttributeError: 'dict' object has no attribute 'userdata'
HOOK-ERROR in after_scenario: AttributeError: 'NoneType' object has no attribute 'stop'
```

Apparently #464 uses the `userdata` attribute from the behave Configuration object. However, the `allure_report` hook still passes an ordinary dict into the `AllureListener`. This PR fixes the problem by putting in a proper Configuration object. It also will populate `userdata` correctly from the configuration including command line arguments as well. 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
