### PR TITLE
Fix showing tags if mark has some value in -> issue-488 

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -86,7 +86,7 @@ def pytest_markers(item):
         if marker is None:
             continue
         user_tag_mark = (not marker.args and not marker.kwargs)
-        if marker.name == "marker" or user_tag_mark:
+        if marker.name or user_tag_mark:
             yield mark_to_str(marker)
 
 


### PR DESCRIPTION
### Context
[Issue 488](https://github.com/allure-framework/allure-python/issues/488)
@pytest.mark.some_marker('arg') does no add to allure report tags. 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
