### PR TITLE
issue-488 -> fix showing tags if mark has some value in

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -86,7 +86,7 @@ def pytest_markers(item):
         if marker is None:
             continue
         user_tag_mark = (not marker.args and not marker.kwargs)
-        if marker.name == "marker" or user_tag_mark:
+        if marker.name or user_tag_mark:
             yield mark_to_str(marker)
 
 

--- a/allure-pytest/test/acceptance/label/tag/tag_test.py
+++ b/allure-pytest/test/acceptance/label/tag/tag_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from allure_commons.utils import represent
-from hamcrest import assert_that, not_
+from hamcrest import assert_that
 from allure_commons_test.report import has_test_case
 from allure_commons_test.label import has_tag
 
@@ -24,7 +24,7 @@ def test_pytest_marker(executed_docstring_source):
                 )
 
 
-def test_omit_pytest_markers(executed_docstring_source):
+def test_pytest_markers(executed_docstring_source):
     """
     >>> import pytest
 
@@ -33,7 +33,7 @@ def test_omit_pytest_markers(executed_docstring_source):
     ... @pytest.mark.parametrize("param", ["foo"])
     ... @pytest.mark.skipif(False, reason="reason2")
     ... @pytest.mark.skipif(False, reason="reason1")
-    ... def test_omit_pytest_markers_example(param):
+    ... def test_pytest_markers_example(param):
     ...     pass
     """
 
@@ -41,19 +41,19 @@ def test_omit_pytest_markers(executed_docstring_source):
                 has_test_case('test_omit_pytest_markers_example[foo]',
                               has_tag("usermark1"),
                               has_tag("usermark2"),
-                              not_(has_tag("skipif(False, reason='reason2')")),
-                              not_(has_tag("skipif(False, reason='reason1')")),
-                              not_(has_tag("parametrize('param', ['foo'])"))
+                              has_tag("skipif(False, reason='reason2')"),
+                              has_tag("skipif(False, reason='reason1')"),
+                              has_tag("parametrize('param', ['foo'])")
                               )
                 )
 
 
-def test_pytest_marker_with_args(executed_docstring_source):
+def test_pytest_mark_marker_with_args(executed_docstring_source):
     """
     >>> import pytest
 
     >>> @pytest.mark.marker('cool', 'stuff')
-    ... def test_pytest_marker_with_args_example():
+    ... def test_pytest_mark_marker_with_args_example():
     ...     pass
     """
 


### PR DESCRIPTION
### Context
[Issue 488](https://github.com/allure-framework/allure-python/issues/488)
@pytest.mark.some_marker('arg') does no add to allure report tags. 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
