### PR TITLE
Add keys suite and package to behave allure results (fixes #389)

### DIFF
--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -104,6 +104,8 @@ class AllureListener(object):
         test_case.labels.append(Label(name=LabelType.FEATURE, value=scenario.feature.name))
         test_case.labels.append(Label(name=LabelType.FRAMEWORK, value='behave'))
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value=platform_label()))
+        test_case.labels.append(Label(name=LabelType.SUITE, value=scenario.feature.name))
+        test_case.labels.append(Label(name=LabelType.PACKAGE, value=scenario.feature.name))
 
         self.logger.schedule_test(self.current_scenario_uuid, test_case)
 

--- a/allure-python-commons/src/types.py
+++ b/allure-python-commons/src/types.py
@@ -31,6 +31,7 @@ class LabelType(str):
     ID = 'as_id'
     FRAMEWORK = 'framework'
     LANGUAGE = 'language'
+    PACKAGE = 'package'
 
 
 class AttachmentType(Enum):


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

This pr fixes this issue : **Missing list of executed suites #389**

- Allure-behave results dont show features name  in overview page **suites** 
- Allure-behave results dont show feature name in **package** list 

### Motivation

I open this pr to equalize the behaviours between allure-cucumber and allure-behave.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2


