### PR TITLE
Exclusive tests filter by allure pytest labels

### DIFF
--- a/allure-pytest/examples/label/bdd/select_tests_by_bdd.rst
+++ b/allure-pytest/examples/label/bdd/select_tests_by_bdd.rst
@@ -36,8 +36,20 @@ There are some tests marked with BDD labels:
     ... def test_with_another_epic_feature_story():
     ...     pass
 
-If you run ``pytest`` with following options: ``$ pytest tests.py --allure-epics=My Epic --alluredir=./report`` first
-three tests will be runned.
+* If you run ``pytest`` with following options::
 
-And with next options: ``$ pytest tests.py --allure-stories=My Story, Another Story --alluredir=./report`` it will
-run just are first and last test.
+    $ pytest tests.py --allure-epics=My Epic --alluredir=./report
+
+  first three tests will be runned.
+
+* And with next options::
+
+    $ pytest tests.py --allure-stories=My Story, Another Story --alluredir=./report
+
+  it will run just are first and last test.
+
+* If set ``--allure-labels-exclusive`` option, you also can run test by several labels specified::
+
+    $ pytest tests.py --allure-labels-exclusive --allure-epics=My Epic --allure-features=My Feature --alluredir=./report
+
+  it will run only first two tests.

--- a/allure-pytest/test/integration/pytest_xdist/pytest_xdist_select_test.py
+++ b/allure-pytest/test/integration/pytest_xdist/pytest_xdist_select_test.py
@@ -30,3 +30,30 @@ def test_xdist_and_select_test_by_bdd_label(allured_testdir):
                               ends_with("test_with_feature_boo")
                               )
                 ))
+
+
+@allure.feature("Integration")
+@pytest.mark.real_logger
+def test_select_exclusive_test_by_bdd_labels(allured_testdir):
+    """
+    >>> import pytest
+    >>> import allure
+
+    >>> @allure.feature("boo")
+    ... def test_with_feature_boo():
+    ...     print ("hello")
+
+    >>> @allure.feature("boo", "foo")
+    ... def test_with_feature_boo_and_foo():
+    ...     print ("hello")
+    """
+
+    allured_testdir.parse_docstring_source()
+    allured_testdir.run_with_allure("-v", "--allure-features=boo,foo", "--allure-labels-exclusive", "-n1")
+
+    assert_that(allured_testdir.allure_report,
+                has_only_testcases(
+                    has_entry("fullName",
+                              ends_with("test_with_feature_boo_and_foo")
+                              )
+                ))


### PR DESCRIPTION
### Context
I often need run tests that match on several features at once and this pr provide to ability for filtered by labels exclusively.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
