### PR TITLE
Now XFAIL messages contains reason same as XPASS

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -168,9 +168,14 @@ class AllureListener(object):
         status_details = None
 
         if call.excinfo:
+            message = escape_non_unicode_symbols(call.excinfo.exconly())
+            if hasattr(report, 'wasxfail'):
+                reason = report.wasxfail
+                message = ('XFAIL {}'.format(reason) if reason else 'XFAIL') + '\n\n' + message
+            trace = escape_non_unicode_symbols(report.longreprtext)
             status_details = StatusDetails(
-                message=escape_non_unicode_symbols(call.excinfo.exconly()),
-                trace=escape_non_unicode_symbols(report.longreprtext))
+                message=message,
+                trace=trace)
             if (status != Status.SKIPPED
                 and not (call.excinfo.errisinstance(AssertionError)
                          or call.excinfo.errisinstance(pytest.fail.Exception))):

--- a/allure-pytest/test/acceptance/status/xfail_call_status_test.py
+++ b/allure-pytest/test/acceptance/status/xfail_call_status_test.py
@@ -19,29 +19,31 @@ def test_xfail(executed_docstring_source):
     assert_that(executed_docstring_source.allure_report,
                 has_test_case("test_xfail_example",
                               with_status("skipped"),
-                              has_status_details(with_message_contains("AssertionError"),
+                              has_status_details(with_message_contains("XFAIL"),
+                                                 with_message_contains("AssertionError"),
                                                  with_trace_contains("def test_xfail_example():")
                                                  )
                               )
                 )
 
 
-def test_xfail_raise_mentioned_exception(executed_docstring_source):
+def test_xfail_with_reason_raise_mentioned_exception(executed_docstring_source):
     """
     >>> import pytest
 
-    >>> @pytest.mark.xfail(raises=AssertionError)
-    ... def test_xfail_raise_mentioned_exception_example():
+    >>> @pytest.mark.xfail(raises=AssertionError, reason='Some reason')
+    ... def test_xfail_with_reason_raise_mentioned_exception_example():
     ...     assert False
 
     """
 
     assert_that(executed_docstring_source.allure_report,
-                has_test_case("test_xfail_raise_mentioned_exception_example",
+                has_test_case("test_xfail_with_reason_raise_mentioned_exception_example",
                               with_status("skipped"),
-                              has_status_details(with_message_contains("AssertionError"),
+                              has_status_details(with_message_contains("XFAIL Some reason"),
+                                                 with_message_contains("AssertionError"),
                                                  with_trace_contains(
-                                                     "def test_xfail_raise_mentioned_exception_example():")
+                                                     "def test_xfail_with_reason_raise_mentioned_exception_example():")
                                                  )
                               )
                 )


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
