### PR TITLE
Add support for parametrize ids for allure.titled test

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -109,6 +109,11 @@ def allure_package(item):
 def allure_name(item, parameters):
     name = escape_name(item.name)
     title = allure_title(item)
+    if title and getattr(item, 'callspec', None):
+        parametrize_id = item.callspec.id
+        parametrize_params = '-'.join([str(value) for value in item.callspec.params.values()])
+        if parametrize_id != parametrize_params:
+            title = f'{title}[{parametrize_id}]'
     return title.format(**{**parameters, **item.funcargs}) if title else name
 
 

--- a/allure-pytest/test/acceptance/display_name/display_name_test.py
+++ b/allure-pytest/test/acceptance/display_name/display_name_test.py
@@ -73,3 +73,24 @@ def test_fixture_value_in_display_name(executed_docstring_source):
                               has_title("title with fixture value")
                               )
                 )
+
+
+def test_ids_for_display_name(executed_docstring_source):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @allure.title("Title with ids from parametrize:")
+    ... @pytest.mark.parametrize("id", [1,2], ids=['first_id', 'second_id'])
+    ... def test_ids_in_display_name(id):
+    ...     pass
+    """
+
+    assert_that(executed_docstring_source.allure_report,
+                has_test_case("test_ids_in_display_name",
+                              has_title("Title with ids from parametrize:[first_id]")
+                              ),
+                has_test_case("test_ids_in_display_name",
+                              has_title("Title with ids from parametrize:[second_id]")
+                              )
+                )


### PR DESCRIPTION
Fixes: #512 

```python
import allure
import pytest


@allure.title('title_check')
@pytest.mark.parametrize('id', [1, 2], ids=['first', 'second'])
def test_test(id):
    pass


@pytest.mark.parametrize('id, n', [(1, 2), (3, 4)], ids=['first', 'second'])
def test_second(id, n):
    pass


@allure.title('third')
def test_third():
    pass


@allure.title('test with {n}')
@pytest.mark.parametrize('id, n', [(1, 2), (3, 4)], ids=['first', 'second'])
def test_four(id, n):
    pass

```

![image](https://user-images.githubusercontent.com/2121715/101224650-4f6ad200-36a0-11eb-8270-a7020b4e503d.png)
