### PR TITLE
Add type hint for decorated function

### DIFF
--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -8,6 +8,7 @@ from allure_commons.utils import func_parameters, represent
 
 _TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
 
+
 def safely(result):
     if result:
         return result[0]

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -1,10 +1,12 @@
 from functools import wraps
+from typing import Any, Callable, TypeVar
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType
 from allure_commons.utils import uuid4
 from allure_commons.utils import func_parameters, represent
 
+_TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
 
 def safely(result):
     if result:
@@ -159,7 +161,7 @@ class StepContext:
         plugin_manager.hook.stop_step(uuid=self.uuid, title=self.title, exc_type=exc_type, exc_val=exc_val,
                                       exc_tb=exc_tb)
 
-    def __call__(self, func):
+    def __call__(self, func: _TFunc) -> _TFunc:
         @wraps(func)
         def impl(*a, **kw):
             __tracebackhide__ = True


### PR DESCRIPTION
Currently some language servers cannot parse the type of wrapped functions. _TFunc is bounded to the function.

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Decorated function will lose type hint in some Python language servers (e.g Pylance which VSCode will use officially in the future). Language server is working as intended, and if our wrapper does not change arg types, we should add type hint.

See: https://github.com/microsoft/pyright/issues/774#issuecomment-651984836

Example code:
```python
    @allure.step("Get field '{field}' edit status.")
    def get_field_edit_status(self, field: str) -> str:
        """Get edit status of the field

        Args:
            field (str): name of the field, case insensitive

        Returns:
            str: edit status: "read only", "yes", "no".
        """
        field = field.lower()
        row_elem: WebElement = self.fields[field]
        status: str = row_elem.find_element_by_xpath(XPATH).text
        return status.lower()
```
VSCode with Pylance:
![image](https://user-images.githubusercontent.com/12843654/101325970-2cf2d780-389f-11eb-845c-6afe0a82c16f.png)

Argument hint:
![image](https://user-images.githubusercontent.com/12843654/101327185-ee5e1c80-38a0-11eb-9674-a4ca0df8147b.png)

----

After this PR:
![image](https://user-images.githubusercontent.com/12843654/101326209-865b0680-389f-11eb-84f3-f3f77a6e0227.png)

Argument hint:
![image](https://user-images.githubusercontent.com/12843654/101326360-b904ff00-389f-11eb-8a30-5f1655140e6f.png)


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

No new unit test since no function change. Unit test result is the same to before this PR.

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
