### PR TITLE
Fixed that not closed fixture step breaks location of next body steps

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -100,6 +100,8 @@ class AllureListener(object):
         uuid = self._cache.get(item.nodeid)
         test_result = self.allure_logger.get_test(uuid)
         if test_result:
+            self.allure_logger.drop_test(uuid)
+            self.allure_logger.schedule_test(uuid, test_result)
             test_result.start = now()
         yield
         if test_result:

--- a/allure-pytest/test/acceptance/fixture/yield_fixture_test.py
+++ b/allure-pytest/test/acceptance/fixture/yield_fixture_test.py
@@ -1,8 +1,9 @@
 import allure
-from hamcrest import assert_that
-from allure_commons_test.report import has_test_case
-from allure_commons_test.container import has_container
 from allure_commons_test.container import has_before
+from allure_commons_test.container import has_container
+from allure_commons_test.report import has_test_case
+from allure_commons_test.result import has_step
+from hamcrest import assert_that, not_, all_of
 
 
 @allure.feature("Fixture")
@@ -25,3 +26,39 @@ def test_yield_fixture(executed_docstring_source):
                                             ),
                               )
                 )
+
+
+def test_opened_step_function(executed_docstring_source):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @pytest.fixture()
+    ... def yield_fixture():
+    ...     with allure.step("Opened step"):
+    ...         yield
+
+    >>> def test_opened_step(yield_fixture):
+    ...     with allure.step("Body step"):
+    ...         pass
+    """
+
+    assert_that(
+        executed_docstring_source.allure_report,
+        has_test_case(
+            "test_opened_step",
+            all_of(
+                has_step("Body step"),
+                has_container(
+                    executed_docstring_source.allure_report,
+                    has_before(
+                        "yield_fixture",
+                        has_step(
+                            "Opened step",
+                            not_(has_step("Body step"))
+                        )
+                    )
+                ),
+            )
+        )
+    )


### PR DESCRIPTION
The decision may be controversial. After the start of the test, it moves up in the stack so that all the next steps are created from it.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
