### PR TITLE
compare the keyword type case insensitive

### DIFF
--- a/allure-robotframework/src/listener/robot_listener.py
+++ b/allure-robotframework/src/listener/robot_listener.py
@@ -47,9 +47,9 @@ class allure_robotframework(object):
         keyword_type = attributes.get('type')
         # Todo fix value assign
         keyword_name = '{} = {}'.format(attributes.get('assign')[0], name) if attributes.get('assign') else name
-        if keyword_type == RobotKeywordType.SETUP:
+        if keyword_type.lower() == RobotKeywordType.SETUP.lower():
             self.listener.start_before_fixture(keyword_name)
-        elif keyword_type == RobotKeywordType.TEARDOWN:
+        elif keyword_type.lower() == RobotKeywordType.TEARDOWN.lower():
             self.listener.start_after_fixture(keyword_name)
         else:
             self.listener.start_keyword(name)
@@ -57,9 +57,9 @@ class allure_robotframework(object):
     def end_keyword(self, _, attributes):
         messages = self.messages.stop_context()
         keyword_type = attributes.get('type')
-        if keyword_type == RobotKeywordType.SETUP:
+        if keyword_type.lower() == RobotKeywordType.SETUP.lower():
             self.listener.stop_before_fixture(attributes, messages)
-        elif keyword_type == RobotKeywordType.TEARDOWN:
+        elif keyword_type.lower() == RobotKeywordType.TEARDOWN.lower():
             self.listener.stop_after_fixture(attributes, messages)
         else:
             self.listener.stop_keyword(attributes, messages)


### PR DESCRIPTION
The names of keyword types are changed in RF 4.0. The can lead to setup and teardown are missing in the allure report. 
To support RF 3.x and RF 4.0, I think we should do the comparison case insensitively.

Refer to the RF User Guide for details about the change of the keyword type in RF 4.0 - http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#listener-interface

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
