### PR TITLE
Add Status UNKOWN for skipped tests with 'unknown' reason

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,40 +22,40 @@ jobs:
         
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
       run: |
         pushd allure-python-commons-test
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd
 
         pushd allure-python-commons
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd
 
         pushd allure-behave
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd
 
         pushd allure-nose2
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd
 
         pushd allure-pytest
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd
 
         pushd allure-pytest-bdd
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd
 
         pushd allure-robotframework
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --repository testpypi dist/*
         popd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,40 +22,40 @@ jobs:
         
     - name: Build and publish
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         pushd allure-python-commons-test
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd
 
         pushd allure-python-commons
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd
 
         pushd allure-behave
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd
 
         pushd allure-nose2
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd
 
         pushd allure-pytest
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd
 
         pushd allure-pytest-bdd
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd
 
         pushd allure-robotframework
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
         popd

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -188,7 +188,7 @@ class AllureListener(object):
             message = 'XPASS {reason}'.format(reason=reason) if reason else 'XPASS'
             status_details = StatusDetails(message=message)
 
-        if item.get_closest_marker(name="issue"):
+        if item.get_closest_marker(name="allure.issue"):
             status = Status.UNKNOWN
 
         if report.when == 'setup':

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -188,6 +188,9 @@ class AllureListener(object):
             message = 'XPASS {reason}'.format(reason=reason) if reason else 'XPASS'
             status_details = StatusDetails(message=message)
 
+        if item.get_closest_marker(name="issue"):
+            status = Status.UNKNOWN
+
         if report.when == 'setup':
             test_result.status = status
             test_result.statusDetails = status_details

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -188,7 +188,7 @@ class AllureListener(object):
             message = 'XPASS {reason}'.format(reason=reason) if reason else 'XPASS'
             status_details = StatusDetails(message=message)
 
-        if item.get_closest_marker(name="allure.issue"):
+        if item.get_closest_marker(name="bug"):
             status = Status.UNKNOWN
 
         if report.when == 'setup':

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -13,8 +13,8 @@ from allure_commons.model2 import StatusDetails
 from allure_commons.model2 import Parameter
 from allure_commons.model2 import Label, Link
 from allure_commons.model2 import Status
-from allure_commons.types import LabelType, AttachmentType
-from allure_pytest.utils import allure_description, allure_description_html
+from allure_commons.types import LabelType, AttachmentType, LinkType
+from allure_pytest.utils import allure_description, allure_description_html, ALLURE_LINK_MARK
 from allure_pytest.utils import allure_labels, allure_links, pytest_markers
 from allure_pytest.utils import allure_full_name, allure_package, allure_name
 from allure_pytest.utils import allure_suite_labels
@@ -188,8 +188,9 @@ class AllureListener(object):
             message = 'XPASS {reason}'.format(reason=reason) if reason else 'XPASS'
             status_details = StatusDetails(message=message)
 
-        if item.get_closest_marker(name="bug"):
-            status = Status.UNKNOWN
+        for mark in item.iter_markers(name='skip'):
+            if mark.kwargs["reason"] == 'unknown':
+                status = Status.UNKNOWN
 
         if report.when == 'setup':
             test_result.status = status

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -13,8 +13,8 @@ from allure_commons.model2 import StatusDetails
 from allure_commons.model2 import Parameter
 from allure_commons.model2 import Label, Link
 from allure_commons.model2 import Status
-from allure_commons.types import LabelType, AttachmentType, LinkType
-from allure_pytest.utils import allure_description, allure_description_html, ALLURE_LINK_MARK
+from allure_commons.types import LabelType, AttachmentType
+from allure_pytest.utils import allure_description, allure_description_html
 from allure_pytest.utils import allure_labels, allure_links, pytest_markers
 from allure_pytest.utils import allure_full_name, allure_package, allure_name
 from allure_pytest.utils import allure_suite_labels


### PR DESCRIPTION
## What?
Add Status UNKOWN for skipped tests with 'unknown' reason
## Why?
To colorize tests which are not triaged yet in category unknown in allure history trends.

## Usage example
Tests skipped with 'unknown' reason will be colored purple in allure history trends.
```python
@pytest.mark.skip('unknown')
def test_needs_to_be_triaged():
    """Or test which is not completed yet."""
```
![image](https://user-images.githubusercontent.com/17043964/116441892-8cf01780-a85a-11eb-984c-3d20abb16f64.png)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
