### PR TITLE
add keys suite and package to behave allure results (fixes #389)

### DIFF
--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -110,6 +110,8 @@ class AllureListener(object):
         test_case.labels.append(Label(name=LabelType.FEATURE, value=scenario.feature.name))
         test_case.labels.append(Label(name=LabelType.FRAMEWORK, value='behave'))
         test_case.labels.append(Label(name=LabelType.LANGUAGE, value=platform_label()))
+        test_case.labels.append(Label(name=LabelType.SUITE, value=scenario.feature.name))
+        test_case.labels.append(Label(name=LabelType.PACKAGE, value=scenario.feature.name))
 
         self.logger.schedule_test(self.current_scenario_uuid, test_case)
 

--- a/allure-python-commons/src/types.py
+++ b/allure-python-commons/src/types.py
@@ -31,6 +31,7 @@ class LabelType(str):
     ID = 'as_id'
     FRAMEWORK = 'framework'
     LANGUAGE = 'language'
+    PACKAGE = 'package'
 
 
 class AttachmentType(Enum):


### PR DESCRIPTION
### Context
This pr fixes this issue : Missing list of executed suites #389

Allure-behave results dont show features name in overview page suites
Allure-behave results dont show feature name in package list

### Motivation
I open this pr to equalize the behaviours between allure-cucumber and allure-behave.

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
