### PR TITLE
Fix redefined fixtures handling

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -268,13 +268,13 @@ class ItemCache(object):
         self._items = dict()
 
     def get(self, _id):
-        return self._items.get(str(_id))
+        return self._items.get(id(_id))
 
     def push(self, _id):
-        return self._items.setdefault(str(_id), uuid4())
+        return self._items.setdefault(id(_id), uuid4())
 
     def pop(self, _id):
-        return self._items.pop(str(_id), None)
+        return self._items.pop(id(_id), None)
 
 
 def _test_fixtures(item):
@@ -283,8 +283,8 @@ def _test_fixtures(item):
 
     if hasattr(item, "_request") and hasattr(item._request, "fixturenames"):
         for name in item._request.fixturenames:
-            fixturedef = fixturemanager.getfixturedefs(name, item.nodeid)
-            if fixturedef:
-                fixturedefs.append(fixturedef[-1])
+            fixturedefs_pytest = fixturemanager.getfixturedefs(name, item.nodeid)
+            if fixturedefs_pytest:
+                fixturedefs.extend(fixturedefs_pytest)
 
     return fixturedefs

--- a/allure-pytest/test/acceptance/fixture/fixture_test.py
+++ b/allure-pytest/test/acceptance/fixture/fixture_test.py
@@ -237,7 +237,7 @@ def test_fixture_override(allured_testdir):
     allured_testdir.testdir.makepyfile("""
         import pytest
         import allure
-        
+
         @pytest.fixture
         def my_fixture(my_fixture):
             with allure.step('Step in before in redefined fixture'):
@@ -245,7 +245,7 @@ def test_fixture_override(allured_testdir):
             yield
             with allure.step('Step in after in redefined fixture'):
                 pass
-        
+
         def test_with_redefined_fixture(my_fixture):
             pass
     """)


### PR DESCRIPTION
Pytest allows to redefine fixture using results of execution of original fixture (see https://docs.pytest.org/en/stable/fixture.html#overriding-fixtures-on-various-levels for details)
The previous implementation of fixture handling relied on str(fixturedef) which can be identical for both original and redefined fixtures so we use python built-in `id()`
`fixturemanager.getfixturedefs(name, item.nodeid)` returns fixturedefs for both original and redefined fixture so we need to use all results of `fixturemanager.getfixturedefs` and not just the last element.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
