### PR TITLE
Proposal to fix python < 3.5 compatibility issues introduced in version 2.8.24

### DIFF
--- a/allure-behave/setup.py
+++ b/allure-behave/setup.py
@@ -10,9 +10,8 @@ classifiers = [
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
     'Topic :: Software Development :: Testing :: BDD',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
 ]

--- a/allure-nose2/setup.py
+++ b/allure-nose2/setup.py
@@ -10,6 +10,7 @@ classifiers = [
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
 ]

--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -10,6 +10,8 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
 ]
 
 setup_requires = [

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -22,6 +22,8 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
 ]
 
 setup_requires = [

--- a/allure-python-commons/setup.py
+++ b/allure-python-commons/setup.py
@@ -8,6 +8,8 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
 ]
 
 install_requires = [
@@ -33,7 +35,8 @@ def main():
         packages=["allure_commons"],
         package_dir={"allure_commons": 'src'},
         install_requires=install_requires,
-        py_modules=['allure', 'allure_commons']
+        py_modules=['allure', 'allure_commons'],
+        python_requires='>=3.5'
     )
 
 

--- a/allure-robotframework/setup.py
+++ b/allure-robotframework/setup.py
@@ -11,6 +11,8 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Topic :: Software Development :: Quality Assurance',
     'Topic :: Software Development :: Testing',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3 :: Only',
 ]
 
 setup_requires = [


### PR DESCRIPTION
### Context
In release 2.8.24 type hinting was introduced  (#533) to `allure-python-common` package, and no `python_requires` directive has been added to `setup.py` script. It lead to failures on new python <3.5 installations, with package managers installing the newest version 2.9.43 which won't work on those python versions.


I feel like pip should install latest compatible version without needing of user to dig into code and see what the problem is, as, i think, majority of allure-python integration users is QA engineers, who might not have a solid python background to understand what the issue is and how to resolve it. 

#### What is the motivation / use case for changing the behavior?

Provide a better UX for users of deprecated python versions (python2.7 is not the only version which won't work with newest package release, typing module was introduced in 3.5) 


#### Proposal to resolve the issue. 

Currently I can see a three ways of dealing with the problem:

1. Fix metadata for a new release:
1.1 Add `python_requires='>=3.5'` directive to `setup.py` script of `allure-python-commons` package
1.2 Fix classifiers of all packages removing python2 support and adding Python 3 Only classifiers.
1.3 Release 2.9.44 which contains fixed metadata.
1.4 Re-release 2.8.22 version as 2.9.43.1

**This way:**

-  Pinned releases are not broken
-  \>\= Python3.5 installs will install release 2.9.44
- < Python3.5  install will install release 2.9.43.1 which will be compatible with those versions.

2. Same as 1, but instead of re-releasing 2.8.22 - yank all broken releases from pypi (https://www.python.org/dev/peps/pep-0592/) Yanking is done using pypi UI.

**This way:**
- Pinned releases are not broken
-  \>\= Python3.5 installs will install release 2.9.44
- < Python3.5  install will install release 2.8.22
- No 2.9.43.1 version
- Yanking is a new feature, not all installers might support it.

3. Drop deprecated pythons support. Change `README.MD` to make it clear that latest release to work on python < 3.5 is 2.8.22. Maybe add an exception in setup.py script which will be raised if minimal python version doesn't satsified.


PR Is for ways 1 and 2. 

#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests

Unittest are not needed as there were no code changes.

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
