### PR TITLE
Allow user/tests to delete (and hence not just append but modify) any label that is available

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -261,6 +261,14 @@ class AllureListener(object):
         for label in labels if test_result else ():
             test_result.labels.append(Label(label_type, label))
 
+    @allure_commons.hookimpl
+    def remove_label(self, label_types):
+        test_result = self.allure_logger.get_test(None)
+        if test_result:
+            for index, all_available_labels in enumerate(test_result.labels):
+                if all_available_labels.name in label_types:
+                    test_result.labels.pop(index)
+
 
 class ItemCache(object):
 

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -101,12 +101,20 @@ class Dynamic(object):
         plugin_manager.hook.add_label(label_type=label_type, labels=labels)
 
     @staticmethod
+    def del_label(*label_types):
+        plugin_manager.hook.remove_label(label_types=label_types)
+
+    @staticmethod
     def severity(severity_level):
         Dynamic.label(LabelType.SEVERITY, severity_level)
 
     @staticmethod
     def feature(*features):
         Dynamic.label(LabelType.FEATURE, *features)
+
+    @staticmethod
+    def remove_feature():
+        Dynamic.del_label(LabelType.FEATURE)
 
     @staticmethod
     def story(*stories):

--- a/allure-python-commons/src/_hooks.py
+++ b/allure-python-commons/src/_hooks.py
@@ -39,6 +39,10 @@ class AllureUserHooks(object):
         """ label """
 
     @hookspec
+    def remove_label(self, label_type, labels):
+        """ label """
+    
+    @hookspec
     def decorate_as_link(self, url, link_type, name):
         """ url """
 


### PR DESCRIPTION
1) Allows user to clear all data available under label "feature".
2) Allows user to clear all data available under any label.

### Context
[//]: # (
Problem Statement - At present allure.dynamic.feature('Sample Feature Name') : allows user to add as many feature names as possible. However, if a user wants to remove any such feature name added based on certain condition met during runtime he can't. 

For instance - 

1. Lets assume all tests of a mini project belongs to "Feature One". So in all tests we can use allure.dynamic.feature("Feature One") to assign the feature to all tests. 
2. But for just few tests, if certain criteria meets we need to make those tests linked with feature ("Feature Two"). As of now using allure.dynamic.feature("Feature Two") appends the feature name to the lists of feature, thus making the later set of tests available in report under both feature names.

)


#### Checklist
- [ x] [Sign Allure CLA][cla]
- [ ] Provide unit tests
