### PR TITLE
Add historyId for pytest-bdd test result

### DIFF
--- a/allure-pytest-bdd/src/pytest_bdd_listener.py
+++ b/allure-pytest-bdd/src/pytest_bdd_listener.py
@@ -38,6 +38,7 @@ class PytestBDDListener(object):
         full_name = get_full_name(feature, scenario)
         name = get_name(request.node, scenario)
         with self.lifecycle.schedule_test_case(uuid=uuid) as test_result:
+            test_result.historyId = uuid
             test_result.fullName = full_name
             test_result.name = name
             test_result.start = now()


### PR DESCRIPTION
Add history id to fix rerun failed cases not show in tries tab

### Context
The failed case will be count more times in total case count, and the case will show more than one time(failed and rerun passed), but retries tab is nothing show.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
