### PR TITLE
fix none step_result error (fixes #609) 

### DIFF
--- a/allure-pytest-bdd/src/pytest_bdd_listener.py
+++ b/allure-pytest-bdd/src/pytest_bdd_listener.py
@@ -60,7 +60,7 @@ class PytestBDDListener(object):
             test_result.stop = now()
 
     @pytest.hookimpl
-    def pytest_bdd_before_step_call(self, request, feature, scenario, step, step_func, step_func_args):
+    def pytest_bdd_before_step(self, request, feature, scenario, step, step_func):
         parent_uuid = get_uuid(request.node.nodeid)
         uuid = get_uuid(str(id(step)))
         with self.lifecycle.start_step(parent_uuid=parent_uuid, uuid=uuid) as step_result:


### PR DESCRIPTION
fix none step_result error when step failed in step fixture


### Context
Error raise when step failed in step fixture
```
    @pytest.hookimpl
    def pytest_bdd_step_error(self, request, feature, scenario, step, step_func, step_func_args, exception):
        uuid = get_uuid(str(id(step)))
        with self.lifecycle.update_step(uuid=uuid) as step_result:
>           step_result.status = Status.FAILED
E           AttributeError: 'NoneType' object has no attribute 'status'

.venv/lib/python3.9/site-packages/allure_pytest_bdd/pytest_bdd_listener.py:79: AttributeError
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
