### PR TITLE
fixes #586

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -114,7 +114,12 @@ class AllureListener(object):
         test_result = self.allure_logger.get_test(uuid)
         test_result.labels.extend([Label(name=name, value=value) for name, value in allure_labels(item)])
         test_result.labels.extend([Label(name=LabelType.TAG, value=value) for value in pytest_markers(item)])
-        test_result.labels.extend([Label(name=name, value=value) for name, value in allure_suite_labels(item)])
+        default_suite = [Label(name=name, value=value) for name, value in allure_suite_labels(item)]
+        for default in default_suite[::-1]:
+            for label in test_result.labels:
+                if label.name == default.name:
+                    default_suite.remove(default)
+        test_result.labels.extend(default_suite)
         test_result.labels.append(Label(name=LabelType.HOST, value=self._host))
         test_result.labels.append(Label(name=LabelType.THREAD, value=self._thread))
         test_result.labels.append(Label(name=LabelType.FRAMEWORK, value='pytest'))

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -114,12 +114,16 @@ class AllureListener(object):
         test_result = self.allure_logger.get_test(uuid)
         test_result.labels.extend([Label(name=name, value=value) for name, value in allure_labels(item)])
         test_result.labels.extend([Label(name=LabelType.TAG, value=value) for value in pytest_markers(item)])
-        default_suite = [Label(name=name, value=value) for name, value in allure_suite_labels(item)]
-        for default in default_suite[::-1]:
-            for label in test_result.labels:
-                if label.name == default.name:
-                    default_suite.remove(default)
-        test_result.labels.extend(default_suite)
+        default_suites = [Label(name=name, value=value) for name, value in allure_suite_labels(item)]
+        final_default_suites = []
+        label_names = []
+        for label in test_result.labels:
+            label_names.append(label.name)
+
+        for suite in default_suites:
+            if suite.name not in label_names:
+                final_default_suites.append(suite)
+        test_result.labels.extend(final_default_suites)
         test_result.labels.append(Label(name=LabelType.HOST, value=self._host))
         test_result.labels.append(Label(name=LabelType.THREAD, value=self._thread))
         test_result.labels.append(Label(name=LabelType.FRAMEWORK, value='pytest'))

--- a/allure-pytest/test/acceptance/label/suite/default_suite_test.py
+++ b/allure-pytest/test/acceptance/label/suite/default_suite_test.py
@@ -1,4 +1,5 @@
 import pytest
+import allure
 from hamcrest import assert_that, anything, not_
 from allure_commons_test.report import has_test_case
 from allure_commons_test.label import has_parent_suite
@@ -38,3 +39,21 @@ def test_default_class_suite(executed_docstring_source):
                               has_sub_suite("TestSuiteClass")
                               )
                 )
+
+@allure.parent_suite('parentSuite')
+@pytest.mark.skip
+def test_default_dynamic_suite(executed_docstring_source):
+    allure.dynamic.suite('dynamic_suite')
+    """
+    >>> def test_default_dynamic_suite_example():
+    ...     pass
+    """
+
+    assert_that(executed_docstring_source.allure_report,
+                has_test_case("test_default_dynamic_suite_example",
+                              has_parent_suite("parentSuite"),  # path to testdir
+                              has_suite("dynamic_suite"),  # created file name
+                              not_(has_sub_suite(anything()))
+                              )
+                )
+    

--- a/allure-pytest/test/acceptance/label/suite/default_suite_test.py
+++ b/allure-pytest/test/acceptance/label/suite/default_suite_test.py
@@ -40,6 +40,7 @@ def test_default_class_suite(executed_docstring_source):
                               )
                 )
 
+
 @allure.parent_suite('parentSuite')
 @pytest.mark.skip
 def test_default_dynamic_suite(executed_docstring_source):
@@ -56,4 +57,4 @@ def test_default_dynamic_suite(executed_docstring_source):
                               not_(has_sub_suite(anything()))
                               )
                 )
-    
+

--- a/allure-pytest/test/acceptance/label/suite/default_suite_test.py
+++ b/allure-pytest/test/acceptance/label/suite/default_suite_test.py
@@ -51,8 +51,8 @@ def test_default_dynamic_suite(executed_docstring_source):
 
     assert_that(executed_docstring_source.allure_report,
                 has_test_case("test_default_dynamic_suite_example",
-                              has_parent_suite("parentSuite"),  # path to testdir
-                              has_suite("dynamic_suite"),  # created file name
+                              has_parent_suite("parentSuite"),
+                              has_suite("dynamic_suite"),
                               not_(has_sub_suite(anything()))
                               )
                 )

--- a/allure-pytest/test/acceptance/label/suite/default_suite_test.py
+++ b/allure-pytest/test/acceptance/label/suite/default_suite_test.py
@@ -57,4 +57,3 @@ def test_default_dynamic_suite(executed_docstring_source):
                               not_(has_sub_suite(anything()))
                               )
                 )
-


### PR DESCRIPTION
Fix issue #586: The dynamic suite and default suite are kept both in report
Current: a case only has one parentSuite/suite/subSuite, and the dynamic has higher priority than the default

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation
.
. An example of good pull request names:
. - Add Russian translation
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
