### PR TITLE
adds support for running tests by suite or parent suite allure label

### DIFF
--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -92,6 +92,24 @@ def pytest_addoption(parser):
                                          help="""Comma-separated list of IDs.
                                          Run tests that have at least one of the specified id labels.""")
 
+    parser.getgroup("general").addoption('--allure-parent-suites',
+                                         action="store",
+                                         dest="allure_parent_suites",
+                                         metavar="PARENT_SUITES_SET",
+                                         default={},
+                                         type=label_type(LabelType.PARENT_SUITE),
+                                         help="""Comma-separated list of parent suites.
+                                         Run tests that have at least one of the specified parent suite labels.""")
+
+    parser.getgroup("general").addoption('--allure-suites',
+                                         action="store",
+                                         dest="allure_suites",
+                                         metavar="SUITES_SET",
+                                         default={},
+                                         type=label_type(LabelType.SUITE),
+                                         help="""Comma-separated list of suites.
+                                         Run tests that have at least one of the specified suite labels.""")
+
     def link_pattern(string):
         pattern = string.split(':', 1)
         if not pattern[0]:
@@ -155,6 +173,8 @@ def select_by_labels(items, config):
                              config.option.allure_features,
                              config.option.allure_stories,
                              config.option.allure_ids,
+                             config.option.allure_suites,
+                             config.option.allure_parent_suites,
                              config.option.allure_severities)
     if arg_labels:
         selected, deselected = [], []


### PR DESCRIPTION
### Context
We would like to be able to run tests based on their suite or parent suite allure labels


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
