### PR TITLE
Fix missing dynamic called fixtures in reports

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -132,6 +132,7 @@ class AllureListener(object):
             container_uuid = self._cache.push(fixturedef)
             container = TestResultContainer(uuid=container_uuid)
             self.allure_logger.start_group(container_uuid, container)
+            self.allure_logger.update_group(container_uuid, children=self._cache.get(request._pyfuncitem.nodeid))
 
         self.allure_logger.update_group(container_uuid, start=now())
 

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -58,6 +58,19 @@ class AllureListener(object):
                                               status=get_status(exc_val),
                                               statusDetails=get_status_details(exc_type, exc_val, exc_tb))
 
+    def _update_fixtures_children(self, item):
+        uuid = self._cache.get(item.nodeid)
+        for fixturedef in _test_fixtures(item):
+            group_uuid = self._cache.get(fixturedef)
+            if group_uuid:
+                group = self.allure_logger.get_item(group_uuid)
+            else:
+                group_uuid = self._cache.push(fixturedef)
+                group = TestResultContainer(uuid=group_uuid)
+                self.allure_logger.start_group(group_uuid, group)
+            if uuid not in group.children:
+                self.allure_logger.update_group(group_uuid, children=uuid)
+
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_runtest_protocol(self, item, nextitem):
         uuid = self._cache.push(item.nodeid)
@@ -71,20 +84,11 @@ class AllureListener(object):
             uuid = self._cache.push(item.nodeid)
             test_result = TestResult(name=item.name, uuid=uuid, start=now(), stop=now())
             self.allure_logger.schedule_test(uuid, test_result)
-
         yield
-
+        self._update_fixtures_children(item)
         uuid = self._cache.get(item.nodeid)
         test_result = self.allure_logger.get_test(uuid)
-        for fixturedef in _test_fixtures(item):
-            group_uuid = self._cache.get(fixturedef)
-            if not group_uuid:
-                group_uuid = self._cache.push(fixturedef)
-                group = TestResultContainer(uuid=group_uuid)
-                self.allure_logger.start_group(group_uuid, group)
-            self.allure_logger.update_group(group_uuid, children=uuid)
         params = item.callspec.params if hasattr(item, 'callspec') else {}
-
         test_result.name = allure_name(item, params)
         full_name = allure_full_name(item)
         test_result.fullName = full_name
@@ -104,12 +108,14 @@ class AllureListener(object):
             self.allure_logger.schedule_test(uuid, test_result)
             test_result.start = now()
         yield
+        self._update_fixtures_children(item)
         if test_result:
             test_result.stop = now()
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item):
         yield
+        self._update_fixtures_children(item)
         uuid = self._cache.get(item.nodeid)
         test_result = self.allure_logger.get_test(uuid)
         test_result.labels.extend([Label(name=name, value=value) for name, value in allure_labels(item)])
@@ -132,7 +138,6 @@ class AllureListener(object):
             container_uuid = self._cache.push(fixturedef)
             container = TestResultContainer(uuid=container_uuid)
             self.allure_logger.start_group(container_uuid, container)
-            self.allure_logger.update_group(container_uuid, children=self._cache.get(request._pyfuncitem.nodeid))
 
         self.allure_logger.update_group(container_uuid, start=now())
 

--- a/allure-pytest/test/acceptance/fixture/fixture_test.py
+++ b/allure-pytest/test/acceptance/fixture/fixture_test.py
@@ -272,3 +272,27 @@ def test_fixture_override(allured_testdir):
                                             ),
                               )
                 )
+
+
+def test_dynamically_called_fixture(allured_testdir):
+    allured_testdir.testdir.makepyfile("""
+        import pytest
+
+        @pytest.fixture
+        def my_fixture():
+            yield
+
+        def test_fixture_example(request):
+            request.getfixturevalue('my_fixture')
+    """)
+
+    allured_testdir.run_with_allure()
+
+    assert_that(allured_testdir.allure_report,
+                has_test_case("test_fixture_example",
+                              has_container(allured_testdir.allure_report,
+                                            has_before("my_fixture"),
+                                            has_after("my_fixture::0"),
+                                            ),
+                              )
+                )

--- a/allure-pytest/test/acceptance/fixture/fixture_test.py
+++ b/allure-pytest/test/acceptance/fixture/fixture_test.py
@@ -321,15 +321,15 @@ def test_dynamically_called_fixture(allured_testdir, parent_scope, child_scope):
                                             has_after("child_manual_call_fixture::0"),
                                             ),
                               not_(has_container(allured_testdir.allure_report,
-                                            has_before("parent_dyn_call_fixture"),
-                                            has_after("parent_dyn_call_fixture::0"),
-                                            ),
-                                  ),
+                                                 has_before("parent_dyn_call_fixture"),
+                                                 has_after("parent_dyn_call_fixture::0"),
+                                                 ),
+                                   ),
                               not_(has_container(allured_testdir.allure_report,
-                                            has_before("child_dyn_call_fixture"),
-                                            ),
-                                  )
-                             )
+                                                 has_before("child_dyn_call_fixture"),
+                                                 ),
+                                   )
+                              )
                 )
     assert_that(allured_testdir.allure_report,
                 has_test_case("test_two",
@@ -338,10 +338,10 @@ def test_dynamically_called_fixture(allured_testdir, parent_scope, child_scope):
                                             has_after("parent_auto_call_fixture::0"),
                                             ),
                               not_(has_container(allured_testdir.allure_report,
-                                            has_before("child_manual_call_fixture"),
-                                            has_after("child_manual_call_fixture::0"),
-                                            ),
-                                  ),
+                                                 has_before("child_manual_call_fixture"),
+                                                 has_after("child_manual_call_fixture::0"),
+                                                 ),
+                                   ),
                               has_container(allured_testdir.allure_report,
                                             has_before("parent_dyn_call_fixture"),
                                             has_after("parent_dyn_call_fixture::0"),
@@ -358,17 +358,17 @@ def test_dynamically_called_fixture(allured_testdir, parent_scope, child_scope):
                                             has_after("parent_auto_call_fixture::0"),
                                             ),
                               not_(has_container(allured_testdir.allure_report,
-                                            has_before("child_manual_call_fixture"),
-                                            has_after("child_manual_call_fixture::0"),
-                                            ),
-                                  ),
+                                                 has_before("child_manual_call_fixture"),
+                                                 has_after("child_manual_call_fixture::0"),
+                                                 ),
+                                   ),
                               has_container(allured_testdir.allure_report,
                                             has_before("parent_dyn_call_fixture"),
                                             has_after("parent_dyn_call_fixture::0"),
                                             ),
                               not_(has_container(allured_testdir.allure_report,
-                                            has_before("child_dyn_call_fixture"),
-                                            ),
-                                  )
-                             )
+                                                 has_before("child_dyn_call_fixture"),
+                                                 ),
+                                   )
+                              )
                 )

--- a/allure-pytest/test/acceptance/fixture/fixture_test.py
+++ b/allure-pytest/test/acceptance/fixture/fixture_test.py
@@ -274,25 +274,101 @@ def test_fixture_override(allured_testdir):
                 )
 
 
-def test_dynamically_called_fixture(allured_testdir):
+@pytest.mark.parametrize(
+    ["parent_scope", "child_scope"],
+    list(combinations_with_replacement(fixture_scopes, 2))
+)
+def test_dynamically_called_fixture(allured_testdir, parent_scope, child_scope):
     allured_testdir.testdir.makepyfile("""
         import pytest
 
-        @pytest.fixture
-        def my_fixture():
+        @pytest.fixture(scope="{parent_scope}", autouse=True)
+        def parent_auto_call_fixture():
             yield
 
-        def test_fixture_example(request):
-            request.getfixturevalue('my_fixture')
-    """)
+        @pytest.fixture(scope="{child_scope}")
+        def child_manual_call_fixture():
+            yield
+
+        @pytest.fixture(scope="{parent_scope}")
+        def parent_dyn_call_fixture():
+            yield
+
+        @pytest.fixture(scope="{child_scope}")
+        def child_dyn_call_fixture(request):
+            request.getfixturevalue('parent_dyn_call_fixture')
+
+        def test_one(child_manual_call_fixture):
+            pass
+
+        def test_two(request):
+            request.getfixturevalue('child_dyn_call_fixture')
+
+        def test_three(request):
+            request.getfixturevalue('parent_dyn_call_fixture')
+    """.format(parent_scope=parent_scope, child_scope=child_scope))
 
     allured_testdir.run_with_allure()
 
     assert_that(allured_testdir.allure_report,
-                has_test_case("test_fixture_example",
+                has_test_case("test_one",
                               has_container(allured_testdir.allure_report,
-                                            has_before("my_fixture"),
-                                            has_after("my_fixture::0"),
+                                            has_before("parent_auto_call_fixture"),
+                                            has_after("parent_auto_call_fixture::0"),
                                             ),
-                              )
+                              has_container(allured_testdir.allure_report,
+                                            has_before("child_manual_call_fixture"),
+                                            has_after("child_manual_call_fixture::0"),
+                                            ),
+                              not_(has_container(allured_testdir.allure_report,
+                                            has_before("parent_dyn_call_fixture"),
+                                            has_after("parent_dyn_call_fixture::0"),
+                                            ),
+                                  ),
+                              not_(has_container(allured_testdir.allure_report,
+                                            has_before("child_dyn_call_fixture"),
+                                            ),
+                                  )
+                             )
+                )
+    assert_that(allured_testdir.allure_report,
+                has_test_case("test_two",
+                              has_container(allured_testdir.allure_report,
+                                            has_before("parent_auto_call_fixture"),
+                                            has_after("parent_auto_call_fixture::0"),
+                                            ),
+                              not_(has_container(allured_testdir.allure_report,
+                                            has_before("child_manual_call_fixture"),
+                                            has_after("child_manual_call_fixture::0"),
+                                            ),
+                                  ),
+                              has_container(allured_testdir.allure_report,
+                                            has_before("parent_dyn_call_fixture"),
+                                            has_after("parent_dyn_call_fixture::0"),
+                                            ),
+                              has_container(allured_testdir.allure_report,
+                                            has_before("child_dyn_call_fixture"),
+                                            ),
+                              ),
+                )
+    assert_that(allured_testdir.allure_report,
+                has_test_case("test_three",
+                              has_container(allured_testdir.allure_report,
+                                            has_before("parent_auto_call_fixture"),
+                                            has_after("parent_auto_call_fixture::0"),
+                                            ),
+                              not_(has_container(allured_testdir.allure_report,
+                                            has_before("child_manual_call_fixture"),
+                                            has_after("child_manual_call_fixture::0"),
+                                            ),
+                                  ),
+                              has_container(allured_testdir.allure_report,
+                                            has_before("parent_dyn_call_fixture"),
+                                            has_after("parent_dyn_call_fixture::0"),
+                                            ),
+                              not_(has_container(allured_testdir.allure_report,
+                                            has_before("child_dyn_call_fixture"),
+                                            ),
+                                  )
+                             )
                 )


### PR DESCRIPTION
### Context

If a fixture is called dynamically via _getfixturevalue_, it is not added to the report.
The problem is that there is no reference to the test in which the fixture is called.
