### PR TITLE
Correctly expanding Scenario Outline params for pytest BDD (fixes #636)

### DIFF
--- a/allure-pytest-bdd/src/utils.py
+++ b/allure-pytest-bdd/src/utils.py
@@ -49,4 +49,6 @@ def get_pytest_report_status(pytest_report):
 def get_params(node):
     if hasattr(node, 'callspec'):
         params = node.callspec.params
+        outlines = params.pop('_pytest_bdd_example', {})
+        params.update(outlines)
         return [Parameter(name=name, value=value) for name, value in params.items()]


### PR DESCRIPTION
This fixes #636 by making each scenario outline param a separate param in the
generated allure JSON.

### Context

When using a `Scenario Outline` and pytest-bdd the parameters passed to the allure listener were of the incorrect type. The `Parameter` class in Allure expects the `value` field to be a `String` but since the callspec has `_pytest_bdd_example` which is a dictionary the value would be of that type. Which would serialise to JSON correctly but cause the following error when Allure generate attempted to deserialise it:

```
Could not read test result file targetreports/6557fe86-9aff-4b34-9198-2a61facbdff6-result.json
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: (sun.nio.ch.ChannelInputStream); line: 1, column: 621] (through reference chain: io.qameta.allure.model.TestResult["parameters"]->java.util.ArrayList[0]->io.qameta.allure.model.Parameter["value"])
```

This change expands the pytest bdd examples so they are each a parameter and brings it in line with other test frameworks and Allure behaviour.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
