### PR TITLE
Do not call not existing start_feature method (fixes #629) 

### DIFF
--- a/allure-behave/src/hooks.py
+++ b/allure-behave/src/hooks.py
@@ -50,7 +50,7 @@ class AllureHooks(object):
         allure_commons.plugin_manager.register(self.listener)
 
     def before_feature(self, context, feature):
-        self.listener.start_feature()
+        pass
 
     def after_feature(self, context, feature):
         self.listener.stop_feature()


### PR DESCRIPTION
### Context
Test execution using behave is failing with the latest (2.9.45) allure-behave version on the following error:
```
HOOK-ERROR in before_feature: AttributeError: 'AllureListener' object has no attribute 'start_feature'
  File "<project-path>/venv/lib/python3.9/site-packages/behave/runner.py", line 564, in run_hook
    self.hooks[name](context, *args)
  File "<project-path>/venv/lib/python3.9/site-packages/allure_behave/hooks.py", line 22, in hook
    allured(*args, **kwargs)
  File "<project-path>/venv/lib/python3.9/site-packages/allure_behave/hooks.py", line 53, in before_feature
    self.listener.start_feature()
```
https://github.com/allure-framework/allure-python/issues/629

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
