### PR TITLE
Use error message for status details of step that does not have exception and is not undefined

### DIFF
--- a/allure-behave/src/utils.py
+++ b/allure-behave/src/utils.py
@@ -64,7 +64,7 @@ def scenario_status(scenario):
 
 def scenario_status_details(scenario):
     for step in scenario.all_steps:
-        if step.exception or step.error_message or step.status == 'undefined':
+        if step.exception or step.error_message or step_status(step) == 'undefined':
             return step_status_details(step)
 
 

--- a/allure-behave/src/utils.py
+++ b/allure-behave/src/utils.py
@@ -64,7 +64,7 @@ def scenario_status(scenario):
 
 def scenario_status_details(scenario):
     for step in scenario.all_steps:
-        if step_status(step) != 'passed':
+        if step.exception or step.error_message or step.status == 'undefined':
             return step_status_details(step)
 
 
@@ -120,10 +120,13 @@ def step_status_details(result):
             result.exc_traceback)
         return StatusDetails(message=format_exception(type(result.exception), result.exception), trace=trace)
 
-    elif result.status == 'undefined':
+    if result.status == 'undefined':
         message = '\nYou can implement step definitions for undefined steps with these snippets:\n\n'
         message += make_undefined_step_snippet(result)
         return StatusDetails(message=message)
+
+    if result.error_message:
+        return StatusDetails(message=result.error_message)
 
 
 def step_table(step):


### PR DESCRIPTION

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

Closes https://github.com/allure-framework/allure-python/issues/649

Use error message for status details of step that does not have exception and is not undefined. This allows test developers to add status details for skipped or passed tests that would otherwise not since there is no exception associated with a step in the scenario. This also allows test developers to categories passed and skipped tests 

![image](https://user-images.githubusercontent.com/10168933/152864437-b32fdc35-c9ea-48c4-af1e-e48785ddedb5.png)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
