### PR TITLE
Fix integration for Allure and pytest_bdd when test parameter is dict

### DIFF
--- a/allure-pytest-bdd/features/outline.feature
+++ b/allure-pytest-bdd/features/outline.feature
@@ -17,8 +17,9 @@ Feature: Scenario outline
       """
       from pytest_bdd import scenario
       from pytest_bdd import given, then, when
+      from pytest_bdd.parsers import cfparse
 
-      @given("<first> step")
+      @given(cfparse("{first} step"))
       def given_step(first):
           pass
 
@@ -26,7 +27,7 @@ Feature: Scenario outline
       def nope_step():
           pass
 
-      @then("step with <second> param")
+      @then(cfparse("step with {second} param"))
       def then_step(second):
           pass
 
@@ -37,15 +38,11 @@ Feature: Scenario outline
     When run pytest-bdd with allure
 
     Then allure report has result for "Outline example" scenario
-    Then this scenario has parameter "first" with value "Alpha"
-    Then this scenario has parameter "second" with value "1"
-    Then this scenario contains "Given <Alpha> step" step
-    Then this scenario contains "Then step with <1> param" step
+    Then this scenario contains "Given Alpha step" step
+    Then this scenario contains "Then step with 1 param" step
 
     Then allure report has result for "Outline example" scenario
-    Then this scenario has parameter "first" with value "Bravo"
-    Then this scenario has parameter "second" with value "2"
-    Then this scenario contains "Given <Bravo> step" step
-    Then this scenario contains "Then step with <2> param" step
+    Then this scenario contains "Given Bravo step" step
+    Then this scenario contains "Then step with 2 param" step
 
 

--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -20,7 +20,7 @@ setup_requires = [
 
 install_requires = [
     "pytest>=4.5.0",
-    "pytest-bdd>=3.0.0",
+    "pytest-bdd>=5.0.0",
     "six>=1.9.0",
 ]
 

--- a/allure-pytest-bdd/test/conftest.py
+++ b/allure-pytest-bdd/test/conftest.py
@@ -7,6 +7,8 @@ from allure_commons.logger import AllureFileLogger
 from .steps import * # noqa F401 F403
 from pytest_bdd import given, when, parsers
 
+pytest_plugins = ["pytester"]
+
 
 @contextmanager
 def fake_logger(path, logger):


### PR DESCRIPTION
### Context
When do `allure serve` on the next generated report
https://gist.github.com/elchupanebrej/4b1d78096ac181ef56edd9b1a1549f57

Allure fails:
https://gist.github.com/elchupanebrej/e753d7d1005c811ff616417ae625df51

[//]: # (
Describe the problem or feature in addition to a link to the issues
)

This happens because of dangerous serialization at 
```python
data = asdict(item, filter=lambda attr, value: not (type(value) != bool and not bool(value)))
```
#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
