### PR TITLE
Add allure plugin name

### DIFF
--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -142,7 +142,7 @@ def pytest_configure(config):
     if report_dir:
         report_dir = os.path.abspath(report_dir)
         test_listener = AllureListener(config)
-        config.pluginmanager.register(test_listener)
+        config.pluginmanager.register(test_listener, 'allure_listener')
         allure_commons.plugin_manager.register(test_listener)
         config.add_cleanup(cleanup_factory(test_listener))
 

--- a/allure-pytest/test/integration/pytest_pluginmanager/pytest_get_allure_plugin_test.py
+++ b/allure-pytest/test/integration/pytest_pluginmanager/pytest_get_allure_plugin_test.py
@@ -1,0 +1,19 @@
+import allure
+from hamcrest import assert_that
+from allure_commons_test.report import has_test_case
+from allure_commons_test.result import with_status
+
+
+@allure.feature("Integration")
+def test_pytest_get_allure_listener_plugin(allured_testdir):
+    allured_testdir.testdir.makepyfile("""
+        def test_pytest_get_allure_listener_plugin(request):
+            assert request.config.pluginmanager.get_plugin('allure_listener')
+    """)
+
+    allured_testdir.run_with_allure()
+
+    assert_that(allured_testdir.allure_report,
+                has_test_case("test_pytest_get_allure_listener_plugin",
+                              with_status("passed"))
+                )


### PR DESCRIPTION
### Context

When registering the allure plugin, its name was not specified.
Because of this, you cannot access the plugin directly by name.

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
