### PR TITLE
Add @allure.manual decorator to simplify ALLURE_MANUAL=True label setting

### DIFF
--- a/allure-pytest/examples/label/manual/allure_manual.rst
+++ b/allure-pytest/examples/label/manual/allure_manual.rst
@@ -3,18 +3,11 @@ Test manual label
 
 By default, ``ALLURE_MANUAL`` label is not set.
 
-Usage of ``allure.manual`` decorator with out arguments (``True`` by default)
+Usage of ``allure.manual`` decorator.
 
     >>> import allure
 
 
-    >>> @allure.manual()
+    >>> @allure.manual
     ... def test_manual():
-    ...     pass
-
-
-``False`` can be set just in case.
-
-    >>> @allure.manual(False)
-    ... def test_manual_false():
     ...     pass

--- a/allure-pytest/examples/label/manual/allure_manual.rst
+++ b/allure-pytest/examples/label/manual/allure_manual.rst
@@ -1,0 +1,20 @@
+Test manual label
+-------------
+
+By default, ``ALLURE_MANUAL`` label is not set.
+
+Usage of ``allure.manual`` decorator with out arguments (``True`` by default)
+
+    >>> import allure
+
+
+    >>> @allure.manual()
+    ... def test_manual():
+    ...     pass
+
+
+``False`` can be set just in case.
+
+    >>> @allure.manual(False)
+    ... def test_manual_false():
+    ...     pass

--- a/allure-pytest/examples/label/manual/allure_manual.rst
+++ b/allure-pytest/examples/label/manual/allure_manual.rst
@@ -11,3 +11,6 @@ Usage of ``allure.manual`` decorator.
     >>> @allure.manual
     ... def test_manual():
     ...     pass
+
+    >>> def test_manual_dynamic():
+    ...     allure.dynamic.manual()

--- a/allure-pytest/test/acceptance/label/manual/manual_test.py
+++ b/allure-pytest/test/acceptance/label/manual/manual_test.py
@@ -1,0 +1,21 @@
+""" ./examples/label/manual/allure_manual.rst """
+
+from hamcrest import assert_that
+from allure_commons_test.report import has_test_case
+from allure_commons_test.label import has_label
+
+
+def test_allure_manual_label(executed_docstring_path):
+    assert_that(executed_docstring_path.allure_report,
+                has_test_case("test_manual",
+                              has_label("ALLURE_MANUAL", True)
+                              )
+                )
+
+
+def test_allure_manual_false_label(executed_docstring_path):
+    assert_that(executed_docstring_path.allure_report,
+                has_test_case("test_manual_false",
+                              has_label("ALLURE_MANUAL", False)
+                              )
+                )

--- a/allure-pytest/test/acceptance/label/manual/manual_test.py
+++ b/allure-pytest/test/acceptance/label/manual/manual_test.py
@@ -1,11 +1,10 @@
-""" ./examples/label/manual/allure_manual.rst """
-
 from hamcrest import assert_that
 from allure_commons_test.report import has_test_case
 from allure_commons_test.label import has_label
 
 
 def test_allure_manual_label(executed_docstring_path):
+    """ ./examples/label/manual/allure_manual.rst """
     assert_that(executed_docstring_path.allure_report,
                 has_test_case("test_manual",
                               has_label("ALLURE_MANUAL", True)

--- a/allure-pytest/test/acceptance/label/manual/manual_test.py
+++ b/allure-pytest/test/acceptance/label/manual/manual_test.py
@@ -11,11 +11,3 @@ def test_allure_manual_label(executed_docstring_path):
                               has_label("ALLURE_MANUAL", True)
                               )
                 )
-
-
-def test_allure_manual_false_label(executed_docstring_path):
-    assert_that(executed_docstring_path.allure_report,
-                has_test_case("test_manual_false",
-                              has_label("ALLURE_MANUAL", False)
-                              )
-                )

--- a/allure-pytest/test/acceptance/label/manual/manual_test.py
+++ b/allure-pytest/test/acceptance/label/manual/manual_test.py
@@ -10,3 +10,12 @@ def test_allure_manual_label(executed_docstring_path):
                               has_label("ALLURE_MANUAL", True)
                               )
                 )
+
+
+def test_allure_manual_label_dynamic(executed_docstring_path):
+    """ ./examples/label/manual/allure_manual.rst """
+    assert_that(executed_docstring_path.allure_report,
+                has_test_case("test_manual_dynamic",
+                              has_label("ALLURE_MANUAL", True)
+                              ),
+                )

--- a/allure-python-commons/allure.py
+++ b/allure-python-commons/allure.py
@@ -10,6 +10,7 @@ from allure_commons._allure import link, issue, testcase
 from allure_commons._allure import Dynamic as dynamic
 from allure_commons._allure import step
 from allure_commons._allure import attach
+from allure_commons._allure import manual
 from allure_commons.types import Severity as severity_level
 from allure_commons.types import AttachmentType as attachment_type
 
@@ -35,5 +36,6 @@ __all__ = [
     'dynamic',
     'severity_level',
     'attach',
-    'attachment_type'
+    'attachment_type',
+    'manual'
 ]

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -144,6 +144,10 @@ class Dynamic(object):
     def sub_suite(sub_suite_name):
         Dynamic.label(LabelType.SUB_SUITE, sub_suite_name)
 
+    @staticmethod
+    def manual():
+        return Dynamic.label(LabelType.MANUAL, True)
+
 
 def step(title):
     if callable(title):

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -70,8 +70,11 @@ def id(id):
     return label(LabelType.ID, id)
 
 
-def manual():
-    return label(LabelType.MANUAL, True)
+def manual(fn):
+    def inner():
+        return Dynamic.label(LabelType.MANUAL, True)
+
+    return inner
 
 
 def link(url, link_type=LinkType.LINK, name=None):
@@ -174,6 +177,7 @@ class StepContext:
             args = list(map(lambda x: represent(x), a))
             with StepContext(self.title.format(*args, **params), params):
                 return func(*a, **kw)
+
         return impl
 
 

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -69,6 +69,9 @@ def tag(*tags):
 def id(id):
     return label(LabelType.ID, id)
 
+def manual(is_manual=True):
+    return label(LabelType.MANUAL, is_manual)
+
 
 def link(url, link_type=LinkType.LINK, name=None):
     return safely(plugin_manager.hook.decorate_as_link(url=url, link_type=link_type, name=name))

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -69,6 +69,7 @@ def tag(*tags):
 def id(id):
     return label(LabelType.ID, id)
 
+
 def manual(is_manual=True):
     return label(LabelType.MANUAL, is_manual)
 

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -70,8 +70,8 @@ def id(id):
     return label(LabelType.ID, id)
 
 
-def manual(is_manual=True):
-    return label(LabelType.MANUAL, is_manual)
+def manual():
+    return label(LabelType.MANUAL, True)
 
 
 def link(url, link_type=LinkType.LINK, name=None):

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -71,10 +71,7 @@ def id(id):
 
 
 def manual(fn):
-    def inner():
-        return Dynamic.label(LabelType.MANUAL, True)
-
-    return inner
+    return label(LabelType.MANUAL, True)(fn)
 
 
 def link(url, link_type=LinkType.LINK, name=None):

--- a/allure-python-commons/src/types.py
+++ b/allure-python-commons/src/types.py
@@ -31,6 +31,7 @@ class LabelType(str):
     ID = 'as_id'
     FRAMEWORK = 'framework'
     LANGUAGE = 'language'
+    MANUAL = 'ALLURE_MANUAL'
 
 
 class AttachmentType(Enum):


### PR DESCRIPTION
### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
For now, to mark your test case as a manual, you need to use decorator ``@allure.label("ALLURE_MANUAL", True)``. This thing is not intuitive and not even stated in documentation.

This PR is adding ``@allure.manual`` decorator which is replacing this usage.
#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
