### PR TITLE
Failed fixtures don't break test name templating from fixture values

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import six
 import pytest
 from itertools import chain, islice
-from allure_commons.utils import represent
+from allure_commons.utils import represent, SafeFormatter
 from allure_commons.utils import format_exception, format_traceback, escape_non_unicode_symbols
 from allure_commons.model2 import Status
 from allure_commons.model2 import StatusDetails
@@ -111,7 +111,7 @@ def allure_package(item):
 def allure_name(item, parameters):
     name = escape_name(item.name)
     title = allure_title(item)
-    return title.format(**{**parameters, **item.funcargs}) if title else name
+    return SafeFormatter().format(title, **{**parameters, **item.funcargs}) if title else name
 
 
 def allure_full_name(item):

--- a/allure-pytest/test/acceptance/display_name/display_name_test.py
+++ b/allure-pytest/test/acceptance/display_name/display_name_test.py
@@ -97,3 +97,24 @@ def test_display_name_with_features(allured_testdir):
                               has_title("Titled test with features")
                               )
                 )
+
+
+def test_failed_fixture_value_in_display_name(executed_docstring_source):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @pytest.fixture
+    ... def fix():
+    ...     raise AssertionError("Fixture failed for some reason")
+
+    >>> @allure.title('title with {fix}')
+    ... def test_fixture_value_name(fix):
+    ...     pass
+    """
+
+    assert_that(executed_docstring_source.allure_report,
+                has_test_case("test_fixture_value_name",
+                              has_title("title with {fix}")
+                              )
+                )


### PR DESCRIPTION
### Context
Fixes #670 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
