### PR TITLE
Fix duplicated fixtures after 2.11.0 release

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -115,7 +115,6 @@ class AllureListener(object):
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item):
         yield
-        self._update_fixtures_children(item)
         uuid = self._cache.get(item.nodeid)
         test_result = self.allure_logger.get_test(uuid)
         test_result.labels.extend([Label(name=name, value=value) for name, value in allure_labels(item)])


### PR DESCRIPTION
No need to update fixtures in test teardown because all fixtures are already finished at this moment and no way to run they again

Fixes #695 
### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
