### PR TITLE
Fix allure_full_name parsing when square bracers is in param contents

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -114,13 +114,11 @@ def allure_name(item, parameters):
     return SafeFormatter().format(title, **{**parameters, **item.funcargs}) if title else name
 
 
-def allure_full_name(item):
-    parts = item.nodeid.split('::')
+def allure_full_name(item: pytest.Item):
     package = allure_package(item)
-    clazz = '.{clazz}'.format(clazz=parts[1]) if len(parts) > 2 else ''
-    test_with_params = parts[-1]
-    test = test_with_params.rsplit("[", 1)[0]
-    full_name = '{package}{clazz}#{test}'.format(package=package, clazz=clazz, test=test)
+    class_name = f".{item.parent.name}" if isinstance(item.parent, pytest.Class) else ''
+    test = item.originalname if isinstance(item, pytest.Function) else item.name.split("[")[0]
+    full_name = f'{package}{class_name}#{test}'
     return escape_name(full_name)
 
 

--- a/allure-pytest/test/acceptance/parametrization/parametrization_test.py
+++ b/allure-pytest/test/acceptance/parametrization/parametrization_test.py
@@ -1,5 +1,5 @@
 import pytest
-from hamcrest import assert_that
+from hamcrest import assert_that, has_entry, ends_with
 from allure_commons_test.report import has_test_case
 from allure_commons_test.result import has_parameter, with_excluded, with_mode
 
@@ -171,5 +171,23 @@ def test_dynamic_parameter_override_from_fixture(executed_docstring_source):
     assert_that(executed_docstring_source.allure_report,
                 has_test_case("test_parameter_override_from_fixture[param-id]",
                               has_parameter("param1", "'readable-value'")
+                              )
+                )
+
+
+def test_fullname_with_braces(executed_docstring_source):
+    """
+    >>> import pytest
+    ... import allure
+
+    >>> class TestClass:
+    ...     @pytest.mark.parametrize("param1", ["qwe]["])
+    ...     def test_with_braces(self, param1):
+    ...         pass
+    """
+    assert_that(executed_docstring_source.allure_report,
+                has_test_case("test_with_braces[qwe][]",
+                              has_entry('fullName', ends_with(".TestClass#test_with_braces")),
+                              has_parameter("param1", "'qwe]['")
                               )
                 )

--- a/allure-pytest/test/integration/pytest_doctest/pytest_doctest_test.py
+++ b/allure-pytest/test/integration/pytest_doctest/pytest_doctest_test.py
@@ -5,7 +5,7 @@ from allure_commons_test.result import with_status
 
 
 @allure.feature("Integration")
-def test_pytest_docktest(allured_testdir):
+def test_pytest_doctest(allured_testdir):
     allured_testdir.testdir.makepyfile('''
         def some_func():
             """
@@ -19,6 +19,6 @@ def test_pytest_docktest(allured_testdir):
     allured_testdir.run_with_allure("--doctest-modules")
 
     assert_that(allured_testdir.allure_report,
-                has_test_case("test_pytest_docktest.some_func",
+                has_test_case("test_pytest_doctest.some_func",
                               with_status("passed"))
                 )


### PR DESCRIPTION
fixes #622

also fix typo in test names

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
