### PR TITLE
Fix failed doctest status reporting

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -307,6 +307,7 @@ def _test_fixtures(item):
 
     return fixturedefs
 
+
 def _exception_brokes_test(exception):
     return not isinstance(exception, (
         AssertionError,

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -1,4 +1,5 @@
 import pytest
+import doctest
 import allure_commons
 from allure_commons.utils import escape_non_unicode_symbols
 from allure_commons.utils import now
@@ -185,9 +186,9 @@ class AllureListener(object):
             status_details = StatusDetails(
                 message=message,
                 trace=trace)
-            if (status != Status.SKIPPED
-                    and not (call.excinfo.errisinstance(AssertionError)
-                             or call.excinfo.errisinstance(pytest.fail.Exception))):
+
+            exception = call.excinfo.value
+            if (status != Status.SKIPPED and _exception_brokes_test(exception)):
                 status = Status.BROKEN
 
         if status == Status.PASSED and hasattr(report, 'wasxfail'):
@@ -305,3 +306,10 @@ def _test_fixtures(item):
                 fixturedefs.extend(fixturedefs_pytest)
 
     return fixturedefs
+
+def _exception_brokes_test(exception):
+    return not isinstance(exception, (
+        AssertionError,
+        pytest.fail.Exception,
+        doctest.DocTestFailure
+    ))

--- a/allure-pytest/test/integration/pytest_doctest/pytest_doctest_test.py
+++ b/allure-pytest/test/integration/pytest_doctest/pytest_doctest_test.py
@@ -23,6 +23,7 @@ def test_pytest_doctest(allured_testdir):
                               with_status("passed"))
                 )
 
+
 @allure.feature("Integration")
 def test_pytest_doctest_failed(allured_testdir):
     allured_testdir.testdir.makepyfile('''
@@ -44,6 +45,7 @@ def test_pytest_doctest_failed(allured_testdir):
             with_status("failed")
         )
     )
+
 
 @allure.feature("Integration")
 def test_pytest_doctest_broken(allured_testdir):

--- a/allure-pytest/test/integration/pytest_doctest/pytest_doctest_test.py
+++ b/allure-pytest/test/integration/pytest_doctest/pytest_doctest_test.py
@@ -22,3 +22,44 @@ def test_pytest_doctest(allured_testdir):
                 has_test_case("test_pytest_doctest.some_func",
                               with_status("passed"))
                 )
+
+@allure.feature("Integration")
+def test_pytest_doctest_failed(allured_testdir):
+    allured_testdir.testdir.makepyfile('''
+        def some_func():
+            """
+            >>> some_func()
+            True
+            """
+            return not True
+
+    ''')
+
+    allured_testdir.run_with_allure("--doctest-modules")
+
+    assert_that(
+        allured_testdir.allure_report,
+        has_test_case(
+            "test_pytest_doctest_failed.some_func",
+            with_status("failed")
+        )
+    )
+
+@allure.feature("Integration")
+def test_pytest_doctest_broken(allured_testdir):
+    allured_testdir.testdir.makepyfile('''
+        def some_func():
+            """
+            >>> raise ValueError()
+            """
+    ''')
+
+    allured_testdir.run_with_allure("--doctest-modules")
+
+    assert_that(
+        allured_testdir.allure_report,
+        has_test_case(
+            "test_pytest_doctest_broken.some_func",
+            with_status("broken")
+        )
+    )


### PR DESCRIPTION
Failed doctests executed through the pytest adapter now are reported as failed instead of broken.

This applies only to tests with invalid example (i.e., where an expected value of an example does not match an actual one).
If a doctest is interrupted with an unexpected exception it is still reported as broken as before.
