### PR TITLE
Fix table data to csv conversion in allure-behave

### DIFF
--- a/allure-behave/features/step.feature
+++ b/allure-behave/features/step.feature
@@ -82,3 +82,20 @@ Feature: Step
       And scenario contains step "Given passed step with attachment"
       And this step has attachment
       And this step has "passed" status
+
+  Scenario: Step with table data containing comma
+    Given feature definition
+        """
+        Feature: Step with data
+
+          Scenario: Step with a table data containing comma
+            Given step with a table data
+              |Items A|Items B|
+              |Item 1, Item 2|Item 3, Item 4|
+        """
+    When I run behave with allure formatter
+    Then allure report has a scenario with name "Step with a table data containing comma"
+    And scenario contains step "Given step with a table data"
+    And this step has attachment ".table" with the following data
+      |Items A|Items B|
+      |Item 1, Item 2|Item 3, Item 4|

--- a/allure-behave/pyproject.toml
+++ b/allure-behave/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.poe.tasks]
-linter = "flake8 ./src"
+linter = "flake8 --extend-ignore=A003 ./src"
 tests = """behave -f allure_behave.formatter:AllureFormatter -o allure-results
               -f pretty ./features"""

--- a/allure-behave/requirements.txt
+++ b/allure-behave/requirements.txt
@@ -1,3 +1,3 @@
 poethepoet
 # linters
-flake8==5.*
+flake8

--- a/allure-behave/src/utils.py
+++ b/allure-behave/src/utils.py
@@ -1,3 +1,5 @@
+import csv
+import io
 from enum import Enum
 from behave.runner_util import make_undefined_step_snippet
 from allure_commons.types import Severity, LabelType
@@ -124,10 +126,11 @@ def step_status_details(result):
 
 
 def step_table(step):
-    table = [','.join(step.table.headings)]
-    for row in step.table.rows:
-        table.append(','.join(list(row)))
-    return '\n'.join(table)
+    with io.StringIO() as buffer:
+        writer = csv.writer(buffer)
+        writer.writerow(step.table.headings)
+        writer.writerows(r.cells for r in step.table.rows)
+        return buffer.getvalue()
 
 
 def is_planned_scenario(scenario, test_plan):

--- a/allure-nose2/requirements.txt
+++ b/allure-nose2/requirements.txt
@@ -1,4 +1,4 @@
 poethepoet
 # linters
-flake8==4.*
+flake8
 flake8-builtins

--- a/allure-pytest-bdd/requirements.txt
+++ b/allure-pytest-bdd/requirements.txt
@@ -1,5 +1,5 @@
 mock
 poethepoet
 # linters
-flake8==4.*
+flake8
 flake8-builtins

--- a/allure-pytest/requirements.txt
+++ b/allure-pytest/requirements.txt
@@ -8,5 +8,5 @@ pytest-xdist
 pytest-lazy-fixture
 poethepoet
 # linters
-flake8==5.*
+flake8
 flake8-builtins

--- a/allure-python-commons-test/requirements.txt
+++ b/allure-python-commons-test/requirements.txt
@@ -2,5 +2,5 @@
 pyhamcrest
 poethepoet
 # linters
-flake8==5.*
+flake8
 flake8-builtins

--- a/allure-python-commons-test/src/container.py
+++ b/allure-python-commons-test/src/container.py
@@ -21,8 +21,8 @@ class HasContainer(BaseMatcher):
     def describe_to(self, description):
         description.append_text('describe me later').append_list('[', ', ', ']', self.matchers)
 
-    def describe_mismatch(self, item, mismatch_descaription):
-        self.matches(item, mismatch_descaription)
+    def describe_mismatch(self, item, mismatch_description):
+        self.matches(item, mismatch_description)
 
 
 def has_container(report, *matchers):

--- a/allure-python-commons-test/src/content.py
+++ b/allure-python-commons-test/src/content.py
@@ -1,0 +1,24 @@
+import csv
+import io
+
+from hamcrest.core.base_matcher import BaseMatcher
+
+
+class CsvEquivalent(BaseMatcher):
+    def __init__(self, rows, **csv_kwargs):
+        self.__rows = rows
+        self.__csv_kwargs = csv_kwargs
+
+    def _matches(self, item):
+        with io.StringIO(item, newline="") as stream:
+            reader = csv.reader(stream, **self.__csv_kwargs)
+            return list(reader) == self.__rows
+
+    def describe_to(self, description):
+        description.append_text(
+            f"csv document equivalent to {self.__rows!r}"
+        )
+
+
+def csv_equivalent(rows, **csv_kwargs):
+    return CsvEquivalent(rows, **csv_kwargs)

--- a/allure-python-commons-test/src/lookup.py
+++ b/allure-python-commons-test/src/lookup.py
@@ -1,0 +1,26 @@
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest import all_of
+
+
+class MapsTo(BaseMatcher):
+    def __init__(self, mapping, *value_matchers):
+        self.__mapping = mapping
+        self.__value_matcher = all_of(*value_matchers)
+
+    def _matches(self, item):
+        if item not in self.__mapping:
+            return False
+        return self.__value_matcher.matches(
+            self.__mapping[item]
+        )
+
+    def describe_to(self, description):
+        keys = list(self.__mapping)
+        description.append_text(
+            f"one of keys {keys!r} mapping to "
+        )
+        self.__value_matcher.describe_to(description)
+
+
+def maps_to(mapping, *value_matchers):
+    return MapsTo(mapping, *value_matchers)

--- a/allure-python-commons-test/src/result.py
+++ b/allure-python-commons-test/src/result.py
@@ -66,6 +66,7 @@ from hamcrest import all_of, anything, not_
 from hamcrest import equal_to, not_none
 from hamcrest import has_entry, has_item
 from hamcrest import contains_string
+from allure_commons_test.lookup import maps_to
 
 
 def has_title(title):
@@ -137,6 +138,19 @@ def has_attachment(attach_type=None, name=None):
                              has_entry('name', name) if name else anything()
                          )
                      ))
+
+
+def has_attachment_with_content(attachments, content_matcher, attach_type=None, name=None):
+    return has_entry(
+        'attachments',
+        has_item(
+            all_of(
+                has_entry('name', name) if name else anything(),
+                has_entry('type', attach_type) if attach_type else anything(),
+                has_entry('source', maps_to(attachments, content_matcher))
+            )
+        )
+    )
 
 
 def with_id():

--- a/allure-python-commons/pyproject.toml
+++ b/allure-python-commons/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.poe.tasks]
-linter = "flake8 ./src"
+linter = "flake8 --extend-ignore=A001,A002,A003 ./src"
 tests = "python -m doctest ./src/*.py"

--- a/allure-python-commons/requirements.txt
+++ b/allure-python-commons/requirements.txt
@@ -4,4 +4,4 @@ pyhamcrest
 pluggy
 poethepoet
 # linters
-flake8==5.*
+flake8

--- a/allure-robotframework/requirements.txt
+++ b/allure-robotframework/requirements.txt
@@ -4,5 +4,5 @@ docutils
 pyhamcrest
 poethepoet
 # linters
-flake8==5.*
+flake8
 flake8-builtins


### PR DESCRIPTION
Contains the following fix:

  - Attachment generation from a table data was rewritten to always create a well-formed CSV-document, even if the data contains special characters (fixes #717)

Also contains the following changes:
  - Remove version specifier of `flake8` dependencies. This fixes issues with the recent dependabot's PRs where the version 6 of the `flake8` cannot be installed in py7 environment. It makes sense to lint with the latest version available anyway.
  - Fix linting poetry scripts of `allure-behave` and `allure-python-commons` to not rely upon whether `flake8-builtins` is installed or not
  - Fix a typo in `allure-python-commons-test/src/container.py`