### PR TITLE
Add --allure-tags command line option to filter test cases by custom tags and pytest markers

### DIFF
--- a/allure-pytest/examples/label/tags/select_tests_by_tags.rst
+++ b/allure-pytest/examples/label/tags/select_tests_by_tags.rst
@@ -1,0 +1,31 @@
+Selecting tests by TAG label
+----------------------------
+
+You can use following commandline options to specify different sets of tests to execute passing a list of
+values as compiled expression:
+
+--allure-tags
+
+There are some tests marked with TAG labels:
+
+    >>> import allure
+
+    >>> @allure.tag("some feature", "smoke")
+    ... def test_feature_smoke():
+    ...     pass
+
+    >>> @allure.tag("some feature", "load")
+    ... def test_feature_load():
+    ...     pass
+
+
+    >>> @pytest.mark.some_feature
+    >>> @pytest.mark.e2e
+    ... def test_feature_e2e():
+    ...     pass
+
+
+If you run ``pytest`` with following options: ``$ pytest tests.py --allure-tags="some_feature and (smoke or e2e)" --alluredir=./report`` first
+and last tests will be runned.
+All spaces in tags in the expression should be replaced with "_".
+The function only works with statically assigned tags by @allure.tag marker.

--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -1,8 +1,10 @@
+import attr
 import argparse
 
 import allure
 import allure_commons
 import os
+import pytest
 
 from allure_commons.types import LabelType
 from allure_commons.logger import AllureFileLogger
@@ -14,6 +16,9 @@ from allure_pytest.listener import AllureListener
 
 from allure_pytest.utils import ALLURE_DESCRIPTION_MARK, ALLURE_DESCRIPTION_HTML_MARK
 from allure_pytest.utils import ALLURE_LABEL_MARK, ALLURE_LINK_MARK
+
+from typing import AbstractSet
+from _pytest.mark import _parse_expression
 
 
 def pytest_addoption(parser):
@@ -101,6 +106,13 @@ def pytest_addoption(parser):
                                          type=label_type(LabelType.ID),
                                          help="""Comma-separated list of IDs.
                                          Run tests that have at least one of the specified id labels.""")
+
+    parser.getgroup("general").addoption('--allure-tags',
+                                         dest="allure_tags",
+                                         metavar="TAGS_SET",
+                                         default='',
+                                         type=str,
+                                         help="An alternative for pytest -m key with support allure tags.")
 
     def link_pattern(string):
         pattern = string.split(':', 1)
@@ -202,11 +214,52 @@ def select_by_testcase(items, config):
         return items, []
 
 
+@attr.s(slots=True, auto_attribs=True)
+class AllureTagsMatcher:
+    own_tags: AbstractSet[str]
+
+    @classmethod
+    def from_item(cls, item: pytest.Item):
+        mark_names = {
+            tag.replace(' ', '_')
+            for mark in item.iter_markers('allure_label')
+            for tag in mark.args
+            if mark.kwargs.get('label_type') == 'tag'
+        }
+        mark_names.update(
+            (
+                mark.name for mark in item.iter_markers()
+                if not mark.args and not mark.kwargs
+            )
+        )
+        return cls(mark_names)
+
+    def __call__(self, name: str) -> bool:
+        return name in self.own_tags
+
+
+def select_by_tags(items: list[pytest.Item], config: pytest.Config) -> None:
+    if not config.option.allure_tags:
+        return items, []
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+    expr = _parse_expression(config.option.allure_tags, "Wrong expression passed to '--allure-tags'")
+    for item in items:
+        if expr.evaluate(AllureTagsMatcher.from_item(item)):
+            selected.append(item)
+        else:
+            deselected.append(item)
+    return selected, deselected
+
+
 def pytest_collection_modifyitems(items, config):
     selected, deselected_by_testcase = select_by_testcase(items, config)
     selected, deselected_by_labels = select_by_labels(selected, config)
+    selected, deselected_by_tags = select_by_tags(selected, config)
 
     items[:] = selected
 
-    if deselected_by_testcase or deselected_by_labels:
-        config.hook.pytest_deselected(items=[*deselected_by_testcase, *deselected_by_labels])
+    if deselected_by_testcase or deselected_by_labels or deselected_by_tags:
+        config.hook.pytest_deselected(
+            items=[*deselected_by_testcase, *deselected_by_labels, *deselected_by_tags]
+        )

--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -4,7 +4,6 @@ import argparse
 import allure
 import allure_commons
 import os
-import pytest
 
 from allure_commons.types import LabelType
 from allure_commons.logger import AllureFileLogger
@@ -219,7 +218,7 @@ class AllureTagsMatcher:
     own_tags: AbstractSet[str]
 
     @classmethod
-    def from_item(cls, item: pytest.Item):
+    def from_item(cls, item):
         mark_names = {
             tag.replace(' ', '_')
             for mark in item.iter_markers('allure_label')
@@ -238,12 +237,11 @@ class AllureTagsMatcher:
         return name in self.own_tags
 
 
-def select_by_tags(items: list[pytest.Item], config: pytest.Config) -> None:
+def select_by_tags(items, config) -> None:
     if not config.option.allure_tags:
         return items, []
-    selected: list[pytest.Item] = []
-    deselected: list[pytest.Item] = []
     expr = _parse_expression(config.option.allure_tags, "Wrong expression passed to '--allure-tags'")
+    selected, deselected = [], []
     for item in items:
         if expr.evaluate(AllureTagsMatcher.from_item(item)):
             selected.append(item)


### PR DESCRIPTION
### Context

"@allure.tag", unlike "@pytest.mark" markers, do not require additional definition and can be assigned several pieces at once. But you can't filter tests by these tags.
Added a cli parameter to filter tests by tags assigned by allure.tag or pytest.mark.
Filtering only works with statically set tags.

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
