### PR TITLE
Fix --allure-severities argument of allure-pytest (fixes #260, #261)

### DIFF
--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -44,7 +44,7 @@ def pytest_addoption(parser):
         def a_label_type(string):
             atoms = set(string.split(','))
             if type_name is LabelType.SEVERITY:
-                if not atoms < legal_values:
+                if not atoms <= legal_values:
                     raise argparse.ArgumentTypeError('Illegal {} values: {}, only [{}] are allowed'.format(
                         type_name,
                         ', '.join(atoms - legal_values),

--- a/allure-pytest/src/plugin.py
+++ b/allure-pytest/src/plugin.py
@@ -4,7 +4,7 @@ import allure
 import allure_commons
 import os
 
-from allure_commons.types import LabelType
+from allure_commons.types import LabelType, Severity
 from allure_commons.logger import AllureFileLogger
 from allure_commons.utils import get_testplan
 
@@ -161,15 +161,24 @@ def pytest_configure(config):
 
 
 def select_by_labels(items, config):
-    arg_labels = set().union(config.option.allure_epics,
-                             config.option.allure_features,
-                             config.option.allure_stories,
-                             config.option.allure_ids,
-                             config.option.allure_severities)
+    arg_labels = set().union(
+        config.option.allure_epics,
+        config.option.allure_features,
+        config.option.allure_stories,
+        config.option.allure_ids,
+        config.option.allure_severities
+    )
     if arg_labels:
         selected, deselected = [], []
         for item in items:
-            selected.append(item) if arg_labels & set(allure_labels(item)) else deselected.append(item)
+            test_labels = set(allure_labels(item))
+            test_severity = allure_label(item, LabelType.SEVERITY)
+            if not test_severity:
+                test_labels.add((LabelType.SEVERITY, Severity.NORMAL))
+            if arg_labels & test_labels:
+                selected.append(item)
+            else:
+                deselected.append(item)
         return selected, deselected
     else:
         return items, []

--- a/allure-pytest/test/acceptance/label/severity/select_severity_test.py
+++ b/allure-pytest/test/acceptance/label/severity/select_severity_test.py
@@ -7,15 +7,21 @@ from hamcrest import assert_that, only_contains, any_of, ends_with
 @pytest.mark.parametrize(
     ["severities", "expected_tests"],
     [
-        (["critical", "minor"],
-         [
-             "test_vip",
-             "test_minor"
-         ]),
-        (["critical"],
-         [
-             "test_vip",
-         ]),
+        pytest.param(
+            ["critical", "minor"],
+            ["test_vip", "test_minor"],
+            id="critical,minor"
+        ),
+        pytest.param(
+            ["critical"],
+            ["test_vip"],
+            id="critical"
+        ),
+        pytest.param(
+            ["normal"],
+            ["test_with_default_severity"],
+            id="normal"
+        )
     ]
 )
 def test_select_by_severity_level(allured_testdir, severities, expected_tests):

--- a/allure-pytest/test/acceptance/label/severity/select_severity_test.py
+++ b/allure-pytest/test/acceptance/label/severity/select_severity_test.py
@@ -21,6 +21,15 @@ from hamcrest import assert_that, only_contains, any_of, ends_with
             ["normal"],
             ["test_with_default_severity"],
             id="normal"
+        ),
+        pytest.param(
+            ["trivial", "minor", "normal", "critical", "blocker"],
+            [
+                "test_vip",
+                "test_with_default_severity",
+                "test_minor"
+            ],
+            id="all"
         )
     ]
 )


### PR DESCRIPTION
This PR fixes two old minor issues with `--allure-severities` described in #260 and #261

#260 is fixed by assuming a test has an implicit `severity=normal` label is no severity labels are present.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2

Closes #260
Closes #261