### PR TITLE
Fix regression: allure_pytest.utils.allure_title crashes if obj attr doesn't exist (Fixes #733)

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -27,7 +27,11 @@ def get_marker_value(item, keyword):
 
 
 def allure_title(item):
-    return getattr(item.obj, "__allure_display_name__", None)
+    return getattr(
+        getattr(item, "obj", None),
+        "__allure_display_name__",
+        None
+    )
 
 
 def allure_description(item):

--- a/tests/allure_behave/behave_runner.py
+++ b/tests/allure_behave/behave_runner.py
@@ -77,7 +77,7 @@ class _InMemoryBehaveRunner(Runner):
             "step_matcher":     matchers.step_matcher,
         }
 
-        # To support the decorators (i.e., @given) with no imports
+        # To support the decorators (e.g., @given) with no imports
         setup_step_decorators(step_globals, self.step_registry)
 
         default_matcher = matchers.current_matcher
@@ -113,7 +113,7 @@ class AllureBehaveRunner(AllureFrameworkRunner):
     LOGGER_PATH = "allure_behave.formatter.AllureFileLogger"
 
     def __init__(self, request: FixtureRequest, pytester: Pytester):
-        super().__init__(request, pytester)
+        super().__init__(request, pytester, AllureBehaveRunner.LOGGER_PATH)
 
     def run_behave(
         self,
@@ -181,7 +181,6 @@ class AllureBehaveRunner(AllureFrameworkRunner):
             testplan_content=testplan_content,
             testplan_path=testplan_path,
             testplan_rst_id=testplan_rst_id,
-            logger_path=AllureBehaveRunner.LOGGER_PATH,
             options=options
         )
 

--- a/tests/allure_nose2/nose2_runner.py
+++ b/tests/allure_nose2/nose2_runner.py
@@ -10,18 +10,14 @@ class AllureNose2Runner(AllureFrameworkRunner):
     LOGGER_PATH = "allure_nose2.plugin.AllureFileLogger"
 
     def __init__(self, request: FixtureRequest, pytester: Pytester):
-        super().__init__(request, pytester)
+        super().__init__(request, pytester, AllureNose2Runner.LOGGER_PATH)
 
     def run_docstring(self):
         docstring = self._find_docstring()
         example_code = script_from_examples(docstring)
         spec = importlib.machinery.ModuleSpec(self.request.node.name, None)
         module = importlib.util.module_from_spec(spec)
-        return self._run(
-            module,
-            example_code,
-            logger_path=AllureNose2Runner.LOGGER_PATH
-        )
+        return self._run(module, example_code)
 
     def _run_framework(self, module, example):
         # We execute the example here because the _run_framework runs in a

--- a/tests/allure_pytest/defects/issue733_test.py
+++ b/tests/allure_pytest/defects/issue733_test.py
@@ -1,5 +1,6 @@
 from allure_pytest.utils import allure_title
 
+
 def test_no_allure_title_error_if_item_obj_missing():
     item_with_no_obj_attr_stub = object()
 

--- a/tests/allure_pytest/defects/issue733_test.py
+++ b/tests/allure_pytest/defects/issue733_test.py
@@ -1,0 +1,6 @@
+from allure_pytest.utils import allure_title
+
+def test_no_allure_title_error_if_item_obj_missing():
+    item_with_no_obj_attr_stub = object()
+
+    assert allure_title(item_with_no_obj_attr_stub) is None

--- a/tests/allure_pytest/pytest_runner.py
+++ b/tests/allure_pytest/pytest_runner.py
@@ -22,8 +22,7 @@ class AllurePytestRunner(AllureFrameworkRunner):
     DOCTEST_RESULT_KEY = StashKey()
 
     def __init__(self, request: FixtureRequest, pytester: Pytester):
-        self.logger_path = AllurePytestRunner.LOGGER_PATH
-        super().__init__(request, pytester)
+        super().__init__(request, pytester, AllurePytestRunner.LOGGER_PATH)
         self.select_plugins("allure_pytest")
 
     def enable_plugins(self, *plugins: str) -> None:
@@ -159,11 +158,7 @@ class AllurePytestRunner(AllureFrameworkRunner):
             *cli_args
         ]
         self.__generate_testfiles(testfile_literals)
-        return self._run(
-            pytest_args,
-            testplan_content=testplan,
-            logger_path=self.logger_path
-        )
+        return self._run(pytest_args, testplan_content=testplan)
 
     def _run_framework(self, options):
         with altered_env(PYTEST_DISABLE_PLUGIN_AUTOLOAD="true"):

--- a/tests/allure_pytest_bdd/conftest.py
+++ b/tests/allure_pytest_bdd/conftest.py
@@ -5,6 +5,6 @@ from tests.allure_pytest.pytest_runner import AllurePytestRunner
 @pytest.fixture
 def allure_pytest_bdd_runner(request, pytester):
     runner = AllurePytestRunner(request, pytester)
-    runner.logger_path = "allure_pytest_bdd.plugin.AllureFileLogger"
+    runner.imported_logger_paths = ["allure_pytest_bdd.plugin.AllureFileLogger"]
     runner.select_plugins("pytest-bdd", "allure_pytest_bdd")
     yield runner

--- a/tests/allure_robotframework/robot_runner.py
+++ b/tests/allure_robotframework/robot_runner.py
@@ -11,7 +11,7 @@ class AllureRobotRunner(AllureFrameworkRunner):
     LOGGER_PATH = "allure_robotframework.robot_listener.AllureFileLogger"
 
     def __init__(self, request: FixtureRequest, pytester: Pytester):
-        super().__init__(request, pytester)
+        super().__init__(request, pytester, AllureRobotRunner.LOGGER_PATH)
 
     def run_robotframework(
         self,
@@ -75,7 +75,6 @@ class AllureRobotRunner(AllureFrameworkRunner):
             testplan_content=testplan_content,
             testplan_path=testplan_path,
             testplan_rst_id=testplan_rst_id,
-            logger_path=AllureRobotRunner.LOGGER_PATH,
             options=self.__resolve_options(options)
         )
 

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -353,11 +353,11 @@ class AllureFrameworkRunner:
 
     """
     def __init__(
-            self,
-            request: FixtureRequest,
-            pytester: Pytester,
-            *imported_logger_paths
-        ):
+        self,
+        request: FixtureRequest,
+        pytester: Pytester,
+        *imported_logger_paths
+    ):
         self.request = request
         self.pytester = pytester
         self.allure_results = None

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -12,7 +12,7 @@ import pytest
 import shutil
 import warnings
 from abc import abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from pathlib import Path
 from pytest import FixtureRequest, Pytester, MonkeyPatch
 from typing import Tuple, Mapping, TypeVar, Generator, Callable, Union
@@ -54,7 +54,7 @@ def allure_plugin_context():
 
 @contextmanager
 def allure_in_memory_context(
-    path: str = None
+    *paths: str
 ) -> Generator[AllureMemoryLogger, None, None]:
     """Creates a context to test an allure integration.
 
@@ -70,28 +70,30 @@ def allure_in_memory_context(
     restored.
 
     Arguments:
-        path (str): a path to a class to replace.
-            Defaults to :code:`"allure_commons.logger.AllureFileLogger"`.
-            Provide this argument if the integration under test imports the
-            logger using the
-            :code:`from allure_commons.logger import AllureFileLogger` syntax.
+        *paths (str): paths to classes to replace with the in-memory logger in
+            addition to :code:`"allure_commons.logger.AllureFileLogger"`.
+            Provide these if the integration under test imports the logger using
+            the :code:`from allure_commons.logger import AllureFileLogger`
+            syntax.
 
     Yields:
-        AllureMemoryLogger: an instance of the in-memory logger, where an output
-            will be collected.
+        AllureMemoryLogger: an instance of the in-memory logger, where the
+            output is collected.
 
     """
-
-    if path is None:
-        path = "allure_commons.logger.AllureFileLogger"
 
     # Plugin context must be set first, because mock patching may cause
     # module loading, thus, side effects, including allure decorators evaluation
     # (and that requires all plugins of nested allure to already be in place).
+    paths = ("allure_commons.logger.AllureFileLogger",) + paths
     with allure_plugin_context():
-        with mock.patch(path) as ReporterMock:
-            ReporterMock.return_value = AllureMemoryLogger()
-            yield ReporterMock.return_value
+        logger = AllureMemoryLogger()
+        with ExitStack() as stack:
+            for path in paths:
+                stack.enter_context(
+                    mock.patch(path)
+                ).return_value = logger
+            yield logger
 
 
 class AllureFileContextValue:
@@ -336,12 +338,31 @@ class AllureFrameworkRunner:
     """An abstract base class for framework test runners to test allure
     integrations.
 
+    Attributes:
+        request (FixtureRequest): an instance of the request fixture.
+        pytester (Pytester): an instance of the pytester fixture.
+        allure_results (AllureMemoryLogger | AllureReport): the latest collected
+            allure results.
+        in_memory (bool): if `True`, the next run collects the results in memory
+            (:attr:`AllureFrameworkRunner.allure_results` is AllureMemoryLogger).
+            Otherwise, the next run creates allure result files and collects the
+            report from them
+            (:attr:`AllureFrameworkRunner.allure_results` is AllureReport).
+        *imported_logger_paths: a sequence of paths to provide to
+            :func:`allure_in_memory_context`.
+
     """
-    def __init__(self, request: FixtureRequest, pytester: Pytester):
+    def __init__(
+            self,
+            request: FixtureRequest,
+            pytester: Pytester,
+            *imported_logger_paths
+        ):
         self.request = request
         self.pytester = pytester
         self.allure_results = None
         self.in_memory = True
+        self.imported_logger_paths = list(imported_logger_paths)
 
     def _run(
         self,
@@ -349,7 +370,6 @@ class AllureFrameworkRunner:
         testplan_content: dict = None,
         testplan_path: PathlikeT = None,
         testplan_rst_id: str = None,
-        logger_path: str = None,
         **kwargs
     ) -> AllureMemoryLogger:
         """Runs the framework and collect the allure results.
@@ -380,7 +400,6 @@ class AllureFrameworkRunner:
         )
         with altered_env(ALLURE_TESTPLAN_PATH=testplan_path):
             output = self.__run_and_collect_results_in_memory(
-                logger_path,
                 args,
                 kwargs
             ) if self.in_memory else self.__run_and_collect_results_from_fs(
@@ -572,8 +591,8 @@ class AllureFrameworkRunner:
         node.stash[cache_key] = result
         return result
 
-    def __run_and_collect_results_in_memory(self, logger_path, args, kwargs):
-        with allure_in_memory_context(logger_path) as output:
+    def __run_and_collect_results_in_memory(self, args, kwargs):
+        with allure_in_memory_context(*self.imported_logger_paths) as output:
             self._run_framework(*args, **kwargs)
             return output
 


### PR DESCRIPTION
### Context
This pull request fixes the regression defect that could be observed if allure-pytest is run against a pytest item with no `obj` attribute or property. This is typical for items that have no meaningful object they can refer. The real-world examples are [pytest-mypy's MypyItem](https://github.com/realpython/pytest-mypy/blob/62c03db621543896ff6166dddd9e9e4f7c78ad7a/src/pytest_mypy.py#L163) and `YamlItem` from [Working with non-python tests](https://docs.pytest.org/en/latest/example/nonpython.html).

The breaking change was introduced during the work on #732. The intent was to get rid of exception-based flow control. The fix is just to add another `getattr` call instead of accessing the `obj` attribute directly.

### AllureFileLogger patching fix
`tests.e2e.allure_in_memory_context` now always patches `allure_commons.logger.AllureFileLogger` in addition to provided paths.

#### Motivation
Generally, when setting up the in-memory logger, we want to patch the class imported by an integration-specific module (e.g., the `allure_pytest.plugin.AllureFileLogger` class), not the original one (i.e., `allure_commons.logger.AllureFileLogger`). This preloads the module and replaces the logger class with the in-memory logger. The module is then removed from `sys.modules` by pytester once the test is completed and the next test repeats the sequence.

This works universally, regardless of whether allure is enabled for the running session or not or whether we test `allure-pytest`, `allure-behave` or other integrations. The only exception is when there is a reference to the patched module that prevents it from being unloaded. The patched module gets reimported by a pytester and the patching appears to have no effect.

#### Example
From `./tests/allure_pytest/defects/issue733_test.py`:
```python
from allure_pytest.utils import allure_title
# ...
```

The ref chain after the first end-to-end test on allure-pytest is executed:

<img src="https://user-images.githubusercontent.com/17935127/223010834-80b62068-59a2-43e4-8362-dd9f290502dd.svg" width="300px">

Consequently, all in-memory end-to-end tests will fail.

Now if we also patch `allure_commons.logger.AllureFileLogger`, the correct class is imported when pytester reimports the module and the tests pass.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

Closes #733 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
