### PR TITLE
Fix squashed results when using rerunfailures (fixes #735)

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -224,6 +224,13 @@ class AllureListener:
                 if report.capstderr:
                     self.attach_data(report.capstderr, "stderr", AttachmentType.TEXT, None)
 
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_logfinish(self, nodeid, location):
+        yield
+        uuid = self._cache.pop(nodeid)
+        if uuid:
+            self.allure_logger.close_test(uuid)
+
     @allure_commons.hookimpl
     def attach_data(self, body, name, attachment_type, extension):
         self.allure_logger.attach_data(uuid4(), body, name=name, attachment_type=attachment_type, extension=extension)

--- a/tests/allure_pytest/externals/pytest_rerunfailures/pytest_rerunfailures_test.py
+++ b/tests/allure_pytest/externals/pytest_rerunfailures/pytest_rerunfailures_test.py
@@ -41,3 +41,28 @@ def test_pytest_rerunfailures(
             with_status(status)
         )
     )
+
+
+@allure.issue("735")
+@allure.feature("Integration")
+def test_separate_result_for_each_rerun(rerunfailures_runner: AllurePytestRunner):
+    testfile_content = (
+        f"""
+        import pytest
+
+        @pytest.mark.flaky(reruns=1)
+        def test_pytest_rerunfailures_example(request):
+            assert False
+        """
+    )
+
+    def __count_labels(tc, name):
+        return len([l["value"] for l in tc["labels"] if l["name"] == name])
+
+    output = rerunfailures_runner.run_pytest(testfile_content)
+
+    assert len(output.test_cases) == 2
+    assert __count_labels(output.test_cases[0], "suite") == 1
+    assert __count_labels(output.test_cases[0], "tag") == 1
+    assert __count_labels(output.test_cases[1], "suite") == 1
+    assert __count_labels(output.test_cases[1], "tag") == 1

--- a/tests/allure_pytest/externals/pytest_rerunfailures/pytest_rerunfailures_test.py
+++ b/tests/allure_pytest/externals/pytest_rerunfailures/pytest_rerunfailures_test.py
@@ -47,7 +47,7 @@ def test_pytest_rerunfailures(
 @allure.feature("Integration")
 def test_separate_result_for_each_rerun(rerunfailures_runner: AllurePytestRunner):
     testfile_content = (
-        f"""
+        """
         import pytest
 
         @pytest.mark.flaky(reruns=1)
@@ -57,7 +57,9 @@ def test_separate_result_for_each_rerun(rerunfailures_runner: AllurePytestRunner
     )
 
     def __count_labels(tc, name):
-        return len([l["value"] for l in tc["labels"] if l["name"] == name])
+        return len(
+            [label["value"] for label in tc["labels"] if label["name"] == name]
+        )
 
     output = rerunfailures_runner.run_pytest(testfile_content)
 


### PR DESCRIPTION
### Context
This PR fixes the regression when pytest-rerunfailures is used. The issue started to occur after the closing of a test result was moved from `pytest_runtest_logfinish` to `pytest_runtest_protocol` to prevent the test result from being omitted from the output under certain conditions (e.g., if `pytest.exit` was called during fixture setup).

To fix that, I put the closing of a test result back to `pytest_runtest_logfinish` while still backing it up with `pytest_runtest_protocol` in case `pytest_runtest_logfinish` is not called. These two closings should cover both issues.

Fixes #735.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
