### PR TITLE
Fix suite label duplication when using dynamic suite functions (Fixes #586)

### DIFF
--- a/allure-pytest/examples/label/suite/custom_suite.rst
+++ b/allure-pytest/examples/label/suite/custom_suite.rst
@@ -1,13 +1,27 @@
 Custom suite
 ____________
 
+Use the `@allure.parent_suite`, `@allure.suite`, or `@allure.sub_suite`
+decorators to overwrite default suite labels:
 
     >>> import allure
 
-    >>> @allure.parent_suite("parent suite name")
-    >>> @allure.suite("suite name")
-    >>> @allure.sub_suite("sub suite name")
-    ... def test_custom_suite():
-    ...     pass
+    >>> class TestCustomSuites:
+    ...     @allure.parent_suite("parent suite name")
+    ...     @allure.suite("suite name")
+    ...     @allure.sub_suite("sub suite name")
+    ...     def test_custom_suites(self):
+    ...         pass
 
 
+Use the `allure.dynamic.parent_suite`, `allure.dynamic.suite`, or
+`allure.dynamic.sub_suite` functions to overwrite default suite labels
+dynamically:
+
+    >>> import allure
+
+    >>> class TestCustomDynamicSuites:
+    ...     def test_custom_dynamic_suites(self):
+    ...         allure.dynamic.parent_suite("parent suite name")
+    ...         allure.dynamic.suite("suite name")
+    ...         allure.dynamic.sub_suite("sub suite name")

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -27,6 +27,12 @@ from allure_commons.utils import md5
 
 class AllureListener:
 
+    SUITE_LABELS = {
+        LabelType.PARENT_SUITE,
+        LabelType.SUITE,
+        LabelType.SUB_SUITE,
+    }
+
     def __init__(self, config):
         self.config = config
         self.allure_logger = AllureReporter()
@@ -128,7 +134,7 @@ class AllureListener:
         test_result = self.allure_logger.get_test(uuid)
         test_result.labels.extend([Label(name=name, value=value) for name, value in allure_labels(item)])
         test_result.labels.extend([Label(name=LabelType.TAG, value=value) for value in pytest_markers(item)])
-        test_result.labels.extend([Label(name=name, value=value) for name, value in allure_suite_labels(item)])
+        self.__apply_default_suites(item, test_result)
         test_result.labels.append(Label(name=LabelType.HOST, value=self._host))
         test_result.labels.append(Label(name=LabelType.THREAD, value=self._thread))
         test_result.labels.append(Label(name=LabelType.FRAMEWORK, value='pytest'))
@@ -283,6 +289,19 @@ class AllureListener:
         else:
             test_result.parameters.append(Parameter(name=name, value=represent(value),
                                                     excluded=excluded or None, mode=mode.value if mode else None))
+
+    def __apply_default_suites(self, item, test_result):
+        default_suites = allure_suite_labels(item)
+        existing_suites = {
+            label.name
+            for label in test_result.labels
+            if label.name in AllureListener.SUITE_LABELS
+        }
+        test_result.labels.extend(
+            Label(name=name, value=value)
+            for name, value in default_suites
+            if name not in existing_suites
+        )
 
 
 class ItemCache:

--- a/tests/allure_pytest/acceptance/label/suite/custom_suite_test.py
+++ b/tests/allure_pytest/acceptance/label/suite/custom_suite_test.py
@@ -1,21 +1,67 @@
 """ ./allure-pytest/examples/label/suite/custom_suite.rst """
 
-from hamcrest import assert_that
+from hamcrest import assert_that, not_
 from tests.allure_pytest.pytest_runner import AllurePytestRunner
 
+import allure
 from allure_commons_test.report import has_test_case
 from allure_commons_test.label import has_suite, has_parent_suite, has_sub_suite
 
 
 def test_custom_suite(allure_pytest_runner: AllurePytestRunner):
-    allure_results = allure_pytest_runner.run_docpath_examples()
+    allure_results = allure_pytest_runner.run_docpath_examples(cache=True)
 
     assert_that(
         allure_results,
         has_test_case(
-            "test_custom_suite",
+            "TestCustomSuites#test_custom_suites",
             has_suite("suite name"),
             has_parent_suite("parent suite name"),
-            has_sub_suite("sub suite name")
+            has_sub_suite("sub suite name"),
+            not_(
+                has_parent_suite(
+                    not_("parent suite name")
+                )
+            ),
+            not_(
+                has_suite(
+                    not_("suite name")
+                )
+            ),
+            not_(
+                has_sub_suite(
+                    not_("sub suite name")
+                )
+            )
+        )
+    )
+
+
+@allure.issue("586", "Issue 586")
+def test_custom_dynamic_suites(allure_pytest_runner: AllurePytestRunner):
+    allure_results = allure_pytest_runner.run_docpath_examples(cache=True)
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "TestCustomDynamicSuites#test_custom_dynamic_suites",
+            has_suite("suite name"),
+            has_parent_suite("parent suite name"),
+            has_sub_suite("sub suite name"),
+            not_(
+                has_parent_suite(
+                    not_("parent suite name")
+                )
+            ),
+            not_(
+                has_suite(
+                    not_("suite name")
+                )
+            ),
+            not_(
+                has_sub_suite(
+                    not_("sub suite name")
+                )
+            )
         )
     )


### PR DESCRIPTION
### Context
Allure-pytest defines default suite labels: parentSuite (optional), suite and subSuite (optional).
If an author of a test uses a decorator (e.g., `@allure.suite`) to assign a custom suite label to a test, allure-pytest doesn't add its default counterpart.

This PR extends this behavior to cover suites added dynamically (e.g., with `allure.dynamic.suite`) as well.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2

Closes #586