### PR TITLE
Fix custom label doc: "allure-labels" -> "allure-label"

### DIFF
--- a/allure-pytest/examples/label/custom/select_tests_by_label.rst
+++ b/allure-pytest/examples/label/custom/select_tests_by_label.rst
@@ -1,16 +1,16 @@
 Select test by label
 -----------------------------
 
-By using ``--allure-labels`` commandline option with a ``lablel_name=label1,label2`` format, only tests with
+By using ``--allure-label`` commandline option with a ``lablel_name=label1,label2`` format, only tests with
 corresponding labels will be run.
 
 
 For example, if you want to run tests with label 'Application' equals to 'desktop' or 'mobile' only,
-run pytest with ``--allure-labels Application=desktop,mobile`` option.
+run pytest with ``--allure-label Application=desktop,mobile`` option.
 
-To filter tests with several different labels multiple ``--allure-labels`` options can be specified:
+To filter tests with several different labels multiple ``--allure-label`` options can be specified:
 
-``--allure-labels Application=desktop,mobile --allure-labels layer=api``
+``--allure-label Application=desktop,mobile --allure-label layer=api``
 
     >>> import allure
 


### PR DESCRIPTION
In the implementation, the --allure-label parameter is specified without the "s"  
The option --allure-labels will not work