### PR TITLE
Replace direct type comparisons with isinstance

### DIFF
--- a/allure-behave/src/utils.py
+++ b/allure-behave/src/utils.py
@@ -115,9 +115,17 @@ def get_hook_name(name, parameters):
 def step_status_details(result):
     if result.exception:
         # workaround for https://github.com/behave/behave/pull/616
-        trace = "\n".join(result.exc_traceback) if type(result.exc_traceback) == list else format_traceback(
-            result.exc_traceback)
-        return StatusDetails(message=format_exception(type(result.exception), result.exception), trace=trace)
+        trace = "\n".join(result.exc_traceback) if isinstance(
+            result.exc_traceback,
+            list
+        ) else format_traceback(result.exc_traceback)
+        return StatusDetails(
+            message=format_exception(
+                type(result.exception),
+                result.exception
+            ),
+            trace=trace
+        )
 
     elif result.status == 'undefined':
         message = '\nYou can implement step definitions for undefined steps with these snippets:\n\n'

--- a/allure-nose2/src/utils.py
+++ b/allure-nose2/src/utils.py
@@ -47,7 +47,7 @@ def labels(test):
         pairs = set()
         for key in keys:
             values = getattr(obj, key, ())
-            for value in (values,) if type(values) == str else values:
+            for value in (values,) if isinstance(values, str) else values:
                 pairs.add((key, value))
         return pairs
 

--- a/allure-python-commons/src/lifecycle.py
+++ b/allure-python-commons/src/lifecycle.py
@@ -30,7 +30,7 @@ class AllureLifecycle:
             item = self._items.get(uuid)
             if item_type is None:
                 return uuid
-            elif type(item) == item_type or isinstance(item, item_type):
+            elif isinstance(item, item_type):
                 return uuid
 
     @contextmanager
@@ -75,7 +75,7 @@ class AllureLifecycle:
 
     def containers(self):
         for item in self._items.values():
-            if type(item) == TestResultContainer:
+            if isinstance(item, TestResultContainer):
                 yield item
 
     @contextmanager

--- a/allure-python-commons/src/logger.py
+++ b/allure-python-commons/src/logger.py
@@ -21,12 +21,7 @@ class AllureFileLogger:
     def _report_item(self, item):
         indent = INDENT if os.environ.get("ALLURE_INDENT_OUTPUT") else None
         filename = item.file_pattern.format(prefix=uuid.uuid4())
-        data = asdict(
-            item,
-            filter=lambda attr, value: not (
-                type(value) != bool and not bool(value)
-            )
-        )
+        data = asdict(item, filter=lambda _, v: v or v is False)
         with io.open(self._report_dir / filename, 'w', encoding='utf8') as json_file:
             json.dump(data, json_file, indent=indent, ensure_ascii=False)
 
@@ -62,12 +57,12 @@ class AllureMemoryLogger:
 
     @hookimpl
     def report_result(self, result):
-        data = asdict(result, filter=lambda attr, value: not (type(value) != bool and not bool(value)))
+        data = asdict(result, filter=lambda _, v: v or v is False)
         self.test_cases.append(data)
 
     @hookimpl
     def report_container(self, container):
-        data = asdict(container, filter=lambda attr, value: not (type(value) != bool and not bool(value)))
+        data = asdict(container, filter=lambda _, v: v or v is False)
         self.test_containers.append(data)
 
     @hookimpl

--- a/allure-python-commons/src/reporter.py
+++ b/allure-python-commons/src/reporter.py
@@ -79,7 +79,7 @@ class AllureReporter:
         for _uuid in reversed(self._items):
             if item_type is None:
                 return self._items.get(_uuid)
-            if type(self._items[_uuid]) == item_type:
+            if isinstance(self._items[_uuid], item_type):
                 return self._items.get(_uuid)
 
     def start_group(self, uuid, group):


### PR DESCRIPTION
### Context
A linting rule E721 was changed in pycodestyle v2.11 referred by flake8 v6.1.0. See more details [here](https://github.com/PyCQA/pycodestyle/blob/1c2147c703e3b934675b270391fab03cb30d73a2/CHANGES.txt#L12) and [here](https://flake8.pycqa.org/en/latest/release-notes/6.1.0.html).

Now these two forms are acceptable:
```python
isinstance(obj, obj_type)
type(obj) is obj_type
```

While this one is not:
```python
type(obj) == obj_type
```

This PR fixes all occurrences of the unacceptable form in the codebase.
