### PR TITLE
Add pytest ParameterSet.id placeholder for @allure.title formatter

### DIFF
--- a/allure-pytest/examples/display_name/display_name.rst
+++ b/allure-pytest/examples/display_name/display_name.rst
@@ -17,3 +17,8 @@ Titles support placeholders for arguments.
     ... @pytest.mark.parametrize('param', [False])
     ... def test_display_name_template(param):
     ...     assert param
+
+    >>> @allure.title("A some test title with ParameterSet id {param_id}")
+    ... @pytest.mark.parametrize('param', [False], ids=["some_id"])
+    ... def test_display_name_parameter_set_id(param):
+    ...     assert param

--- a/allure-pytest/examples/display_name/display_name.rst
+++ b/allure-pytest/examples/display_name/display_name.rst
@@ -18,7 +18,7 @@ Titles support placeholders for arguments.
     ... def test_display_name_template(param):
     ...     assert param
 
-    >>> @allure.title("A some test title with ParameterSet id {param_id}")
+    >>> @allure.title("A test title with ParameterSet id {param_id}")
     ... @pytest.mark.parametrize('param', [False], ids=["some_id"])
     ... def test_display_name_parameter_set_id(param):
     ...     assert param

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -103,7 +103,8 @@ class AllureListener:
         uuid = self._cache.get(item.nodeid)
         test_result = self.allure_logger.get_test(uuid)
         params = self.__get_pytest_params(item)
-        test_result.name = allure_name(item, params)
+        param_id = self.__get_pytest_param_id(item)
+        test_result.name = allure_name(item, params, param_id)
         full_name = allure_full_name(item)
         test_result.fullName = full_name
         test_result.testCaseId = md5(full_name)
@@ -306,6 +307,10 @@ class AllureListener:
     @staticmethod
     def __get_pytest_params(item):
         return item.callspec.params if hasattr(item, 'callspec') else {}
+
+    @staticmethod
+    def __get_pytest_param_id(item):
+        return item.callspec.id if hasattr(item, 'callspec') else None
 
     def __apply_default_suites(self, item, test_result):
         default_suites = allure_suite_labels(item)

--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -110,12 +110,18 @@ def allure_package(item):
     return path.replace('/', '.')
 
 
-def allure_name(item, parameters):
+def allure_name(item, parameters, param_id=None):
     name = item.name
     title = allure_title(item)
+    param_id_kwargs = {}
+    if param_id:
+        # if param_id is an ASCII string, it could have been encoded by pytest (_pytest.compat.ascii_escaped)
+        if param_id.isascii():
+            param_id = param_id.encode().decode("unicode-escape")
+        param_id_kwargs["param_id"] = param_id
     return SafeFormatter().format(
         title,
-        **{**parameters, **item.funcargs}
+        **{**parameters, **item.funcargs, **param_id_kwargs}
     ) if title else name
 
 

--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -121,7 +121,7 @@ def allure_name(item, parameters, param_id=None):
         param_id_kwargs["param_id"] = param_id
     return SafeFormatter().format(
         title,
-        **{**parameters, **item.funcargs, **param_id_kwargs}
+        **{**param_id_kwargs, **parameters, **item.funcargs}
     ) if title else name
 
 

--- a/tests/allure_pytest/acceptance/display_name/display_name_test.py
+++ b/tests/allure_pytest/acceptance/display_name/display_name_test.py
@@ -172,6 +172,7 @@ def test_non_ascii_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
         )
     )
 
+
 def test_explicit_parameter_called_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
     """
     >>> import allure

--- a/tests/allure_pytest/acceptance/display_name/display_name_test.py
+++ b/tests/allure_pytest/acceptance/display_name/display_name_test.py
@@ -171,3 +171,24 @@ def test_non_ascii_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
             has_title("Title with non-ASCII id - Ид,本我,पहचान,بطاقة تعريف")
         )
     )
+
+def test_explicit_parameter_called_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @pytest.mark.parametrize("param_id", [pytest.param("param value", id="some id")])
+    ... @allure.title('Title with id - {param_id}')
+    ... def test_explicit_parameter_called_param_id(param_id):
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_explicit_parameter_called_param_id",
+            has_title("Title with id - param value")
+        )
+    )

--- a/tests/allure_pytest/acceptance/display_name/display_name_test.py
+++ b/tests/allure_pytest/acceptance/display_name/display_name_test.py
@@ -105,3 +105,67 @@ def test_failed_fixture_value_in_display_name(allure_pytest_runner: AllurePytest
             has_title("title with {fix}")
         )
     )
+
+
+def test_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @pytest.mark.parametrize("name", [pytest.param("value", id="some id")])
+    ... @allure.title('Title with id - {param_id}')
+    ... def test_param_id(name):
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_param_id",
+            has_title("Title with id - some id")
+        )
+    )
+
+def test_no_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @pytest.mark.parametrize("param1, param2", [pytest.param("value1", "value2")])
+    ... @allure.title('Title with id - {param_id}')
+    ... def test_no_param_id(param1, param2):
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_no_param_id",
+            has_title("Title with id - value1-value2")
+        )
+    )
+
+def test_non_ascii_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import allure
+    >>> import pytest
+
+    >>> @pytest.mark.parametrize("name", [pytest.param("value", id="Ид,本我,पहचान,بطاقة تعريف")])
+    ... @allure.title('Title with non-ASCII id - {param_id}')
+    ... def test_non_ascii_param_id(name):
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_non_ascii_param_id",
+            has_title("Title with non-ASCII id - Ид,本我,पहचान,بطاقة تعريف")
+        )
+    )

--- a/tests/allure_pytest/acceptance/display_name/display_name_test.py
+++ b/tests/allure_pytest/acceptance/display_name/display_name_test.py
@@ -128,6 +128,7 @@ def test_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
         )
     )
 
+
 def test_no_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
     """
     >>> import allure
@@ -148,6 +149,7 @@ def test_no_param_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
             has_title("Title with id - value1-value2")
         )
     )
+
 
 def test_non_ascii_id_in_display_name(allure_pytest_runner: AllurePytestRunner):
     """


### PR DESCRIPTION
### Context
Currently, to use `ParameterSet.id` (`pytest.param(id=*)`) in `allure.title` you need to use the `request` fixture in combination with the `allure.dynamic.title` function. 
Thus, the complete design looks like this:
```
@pytest.mark.parametrize("name", [pytest.param("value", id="some id")])
def test_1(request)
    allure.dynamic.title(f"Test name with id = {request.node.callspec.id}")
    ...
```
My fix suggests using the following syntax:
```
@pytest.mark.parametrize("name", [pytest.param("value", id="some id")])
@allure.title("Test name with id = {param_id}")
def test_1()
    ...
```

Since many people already assign identifiers to their parameter sets, this syntax will save them from duplicating code. And it will also help avoid situations where a test fails before `allure.dynamic.title` is executed and the test result is left without DisplayName.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
