### PR TITLE
Expected fail of lazy-fixture tests

### DIFF
--- a/allure-behave/pyproject.toml
+++ b/allure-behave/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.poe.tasks]
 linter = "flake8 --extend-ignore=A003 ./src"
-tests = """pytest ../tests/allure_behave"""
+
+[tool.poe.tasks.tests]
+cmd = "pytest ../tests/allure_behave"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }

--- a/allure-nose2/pyproject.toml
+++ b/allure-nose2/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.poe.tasks]
 linter = "flake8 ./src"
-tests = """pytest ../tests/allure_nose2"""
+
+[tool.poe.tasks.tests]
+cmd = "pytest ../tests/allure_nose2"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }

--- a/allure-pytest-bdd/pyproject.toml
+++ b/allure-pytest-bdd/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.poe.tasks]
 linter = "flake8 ./src"
-tests = "pytest ../tests/allure_pytest_bdd"
+
+[tool.poe.tasks.tests]
+cmd = "pytest ../tests/allure_pytest_bdd"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }

--- a/allure-pytest/pyproject.toml
+++ b/allure-pytest/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.poe.tasks]
 linter = "flake8 ./src"
-tests = "pytest ../tests/allure_pytest"
+
+[tool.poe.tasks.tests]
+cmd = "pytest ../tests/allure_pytest"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }

--- a/allure-robotframework/pyproject.toml
+++ b/allure-robotframework/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.poe.tasks]
 linter = "flake8 ./src"
-tests = { shell = """python -m doctest ./src/listener/utils.py &&
-             pytest ../tests/allure_robotframework
-""" }
+
+[tool.poe.tasks.tests]
+shell = "python -m doctest ./src/listener/utils.py && pytest ../tests/allure_robotframework"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,15 @@
 [tool.poe.tasks]
 linter = "flake8 ./allure-*/src ./tests"
-tests = "pytest"
-allure-collect = "pytest -p allure_pytest --alluredir ./.allure-results --clean-alluredir --allure-link-pattern issue:https://github.com/allure-framework/allure-python/issues/{0}"
 allure-generate = "allure generate --clean --output ./.allure-report ./.allure-results"
 allure-open = "allure open ./.allure-report"
+
+[tool.poe.tasks.tests]
+cmd = "pytest"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }
+
+[tool.poe.tasks.allure-collect]
+cmd = "pytest -p allure_pytest --alluredir ./.allure-results --clean-alluredir --allure-link-pattern issue:https://github.com/allure-framework/allure-python/issues/{0}"
+env = { PYTEST_DISABLE_PLUGIN_AUTOLOAD = "true" }
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/tests/allure_pytest/externals/pytest_lazy_fixture/pytest_lazy_fixture_test.py
+++ b/tests/allure_pytest/externals/pytest_lazy_fixture/pytest_lazy_fixture_test.py
@@ -7,6 +7,16 @@ from allure_commons_test.report import has_test_case
 from allure_commons_test.container import has_container
 from allure_commons_test.container import has_before
 
+from packaging import version
+
+pytestmark = pytest.mark.xfail(
+    version.parse(pytest.__version__) >= version.parse("8"),
+    reason=(
+        "Lazy-fixture is incompatible with pytest 8 "
+        "(see TvoroG/pytest-lazy-fixture#65)"
+    ),
+)
+
 
 @pytest.fixture
 def lazy_fixture_runner(allure_pytest_runner: AllurePytestRunner):


### PR DESCRIPTION
### Context
Lazy-fixture is incompatible with pytest 8+ (see TvoroG/pytest-lazy-fixture#65 for more details). Because of this, our tests that check compatibility between allure-pytest and lazy-fixture fail (example: https://github.com/allure-framework/allure-python/actions/runs/7892006564/job/21537573652).

This PR marks those tests as tests with expected failure if they're run under pytest 8+. If the situation doesn't change, we might remove explicit support of `lazy-fixture` entirely in the future.

### Additional changes

#### Disable pytest plugin autoload

All poe testing tasks now run pytest with plugin autoload disabled (via the `PYTEST_DISABLE_PLUGIN_AUTOLOAD` env var). The outer session doesn't need any. And if an inner session requires some plugins, they are always enabled explicitly by the runner.
