### PR TITLE
Fixes #771 allure-behave formatter crash with behave v1.2.7.dev5

### DIFF
--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -97,7 +97,7 @@ class AllureListener:
         self.stop_scenario(context['scenario'])
 
     def stop_scenario(self, scenario):
-        should_run = (scenario.should_run_with_tags(self.behave_config.tags) and
+        should_run = (scenario.should_run_with_tags(self.behave_config.tag_expression) and
                       scenario.should_run_with_name_select(self.behave_config))
         should_drop_skipped_by_option = scenario.status == 'skipped' and not self.behave_config.show_skipped
         should_drop_excluded = self.hide_excluded and (scenario.skip_reason == TEST_PLAN_SKIP_REASON or not should_run)

--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -97,8 +97,11 @@ class AllureListener:
         self.stop_scenario(context['scenario'])
 
     def stop_scenario(self, scenario):
-        should_run = (scenario.should_run_with_tags(self.behave_config.tag_expression) and
-                      scenario.should_run_with_name_select(self.behave_config))
+        if hasattr(self.behave_config, "tag_expression"):  # since behave 1.2.7dev1
+            should_run = scenario.should_run_with_tags(self.behave_config.tag_expression)
+        else:  # till behave 1.2.6
+            should_run = scenario.should_run_with_tags(self.behave_config.tags)
+        should_run &= scenario.should_run_with_name_select(self.behave_config)
         should_drop_skipped_by_option = scenario.status == 'skipped' and not self.behave_config.show_skipped
         should_drop_excluded = self.hide_excluded and (scenario.skip_reason == TEST_PLAN_SKIP_REASON or not should_run)
 

--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -22,6 +22,10 @@ from allure_behave.utils import scenario_labels
 from allure_behave.utils import get_fullname
 from allure_behave.utils import TEST_PLAN_SKIP_REASON
 from allure_behave.utils import get_hook_name
+import behave
+from packaging import version
+
+BEHAVE_1_2_7_OR_GREATER = version.parse(behave.__version__) > version.parse("1.2.6")
 
 
 class AllureListener:
@@ -97,9 +101,9 @@ class AllureListener:
         self.stop_scenario(context['scenario'])
 
     def stop_scenario(self, scenario):
-        if hasattr(self.behave_config, "tag_expression"):  # since behave 1.2.7dev1
+        if BEHAVE_1_2_7_OR_GREATER:
             should_run = scenario.should_run_with_tags(self.behave_config.tag_expression)
-        else:  # till behave 1.2.6
+        else:
             should_run = scenario.should_run_with_tags(self.behave_config.tags)
         should_run &= scenario.should_run_with_name_select(self.behave_config)
         should_drop_skipped_by_option = scenario.status == 'skipped' and not self.behave_config.show_skipped

--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -105,7 +105,7 @@ class AllureListener:
             should_run = scenario.should_run_with_tags(self.behave_config.tag_expression)
         else:
             should_run = scenario.should_run_with_tags(self.behave_config.tags)
-        should_run &= scenario.should_run_with_name_select(self.behave_config)
+        should_run = should_run and scenario.should_run_with_name_select(self.behave_config)
         should_drop_skipped_by_option = scenario.status == 'skipped' and not self.behave_config.show_skipped
         should_drop_excluded = self.hide_excluded and (scenario.skip_reason == TEST_PLAN_SKIP_REASON or not should_run)
 

--- a/tests/allure_behave/behave_runner.py
+++ b/tests/allure_behave/behave_runner.py
@@ -74,17 +74,14 @@ class _InMemoryBehaveRunner(Runner):
         behave.step_registry.registry = self.step_registry = StepRegistry()
         step_globals = {
             "use_step_matcher": matchers.use_step_matcher,
-            "step_matcher":     matchers.step_matcher,
         }
 
         # To support the decorators (e.g., @given) with no imports
         setup_step_decorators(step_globals, self.step_registry)
 
-        default_matcher = matchers.current_matcher
         for step in self.__steps:
             step_module_globals = step_globals.copy()
             exec(step, step_module_globals)
-            matchers.current_matcher = default_matcher
 
     def load_features(self):
         self.features.extend(


### PR DESCRIPTION
This is a fix for issue https://github.com/allure-framework/allure-python/issues/771: with behave v1.2.7.dev5 an error causes the allure_behave report formatter to crash.

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
With behave v1.2.7.dev5 the allure-behave python library crashes every run, with exceptions like the following example:
```
File "/Users/marcocarosi/Code/miniconda3/envs/phoenix3/lib/python3.12/site-packages/allure_behave/listener.py", line 97, in stop_test
self.stop_scenario(context['scenario'])
File "/Users/marcocarosi/Code/miniconda3/envs/phoenix3/lib/python3.12/site-packages/allure_behave/listener.py", line 100, in stop_scenario
should_run = (scenario.should_run_with_tags(self.behave_config.tags) and  # original
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/marcocarosi/Code/miniconda3/envs/phoenix3/lib/python3.12/site-packages/behave/model_core.py", line 398, in should_run_with_tags
return tag_expression.check(self.effective_tags)
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'check'
```
That is a **blocker** for whoever wants to use allure with behave.

#### Checklist
- [v] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
