### PR TITLE
Add run-name to release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,8 @@ jobs:
   commons:
     name: Build commons
     runs-on: ubuntu-latest
+    needs: [pytest-changes, other-changes]
+    if: ${{ needs.pytest-changes.outputs.changed == 'true' || needs.other-changes.outputs.packages != '[]' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -82,7 +84,7 @@ jobs:
     name: Static check
     runs-on: ubuntu-latest
     needs: [commons, pytest-changes, other-changes]
-    if: ${{ needs.pytest-changes.outputs.changed || needs.other-changes.outputs.packages != '[]' }}
+    if: ${{ needs.pytest-changes.outputs.changed == 'true' || needs.other-changes.outputs.packages != '[]' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -101,7 +103,7 @@ jobs:
     name: Test allure-pytest
     runs-on: ubuntu-latest
     needs: [commons, pytest-changes]
-    if: ${{ needs.pytest-changes.outputs.changed }}
+    if: ${{ needs.pytest-changes.outputs.changed == 'true' }}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 name: release allure python
+run-name: Release ${{ github.ref_name }} by ${{ github.actor }}
 
 on:
   release:


### PR DESCRIPTION
### Context
This PR adds the `run-name` property to the release CI workflow. The value includes the version number and the author of the release.

#### Additional changes
The PR also fixes the build CI workflow:

  - allure-pytest build & test now is skipped if no changes detected (in a same manner as the built & test job for other adapters)
  - commons build and linting now are also skipped if no changes detected
