### PR TITLE
Add logs, stdout and stderr to the allure-pytest-bdd report 

### DIFF
--- a/allure-pytest-bdd/src/pytest_bdd_listener.py
+++ b/allure-pytest-bdd/src/pytest_bdd_listener.py
@@ -6,7 +6,6 @@ from allure_commons.model2 import Label
 from allure_commons.model2 import Status
 
 from allure_commons.types import LabelType, AttachmentType
-from allure_commons.reporter import AllureReporter
 from allure_commons.utils import platform_label
 from allure_commons.utils import host_tag, thread_tag
 from allure_commons.utils import md5

--- a/allure-pytest-bdd/src/pytest_bdd_listener.py
+++ b/allure-pytest-bdd/src/pytest_bdd_listener.py
@@ -5,7 +5,8 @@ from allure_commons.utils import uuid4
 from allure_commons.model2 import Label
 from allure_commons.model2 import Status
 
-from allure_commons.types import LabelType
+from allure_commons.types import LabelType, AttachmentType
+from allure_commons.reporter import AllureReporter
 from allure_commons.utils import platform_label
 from allure_commons.utils import host_tag, thread_tag
 from allure_commons.utils import md5
@@ -114,6 +115,12 @@ class PytestBDDListener:
                 if test_result.status == Status.PASSED and status != Status.PASSED:
                     test_result.status = status
                     test_result.statusDetails = status_details
+                if report.caplog:
+                    self.attach_data(report.caplog, "log", AttachmentType.TEXT, None)
+                if report.capstdout:
+                    self.attach_data(report.capstdout, "stdout", AttachmentType.TEXT, None)
+                if report.capstderr:
+                    self.attach_data(report.capstderr, "stderr", AttachmentType.TEXT, None)
 
         if report.when == 'teardown':
             self.lifecycle.write_test_case(uuid=uuid)

--- a/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
+++ b/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
@@ -115,9 +115,7 @@ def test_capture_log(allure_pytest_bdd_runner: AllurePytestRunner, logging):
         """
         import logging
         from pytest_bdd import scenario, given, when, then
-        
         logger = logging.getLogger(__name__)
-        
         @scenario("scenario.feature", "Simple passed example")
         def test_scenario_passes():
             pass

--- a/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
+++ b/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
@@ -1,5 +1,5 @@
 import pytest
-from hamcrest import assert_that
+from hamcrest import assert_that, empty
 from hamcrest import all_of, is_, is_not
 from hamcrest import has_property, has_value
 from hamcrest import contains_string
@@ -57,92 +57,101 @@ def test_capture_stdout_in_bdd(allure_pytest_bdd_runner: AllurePytestRunner, cap
     )
 
 
-# @pytest.mark.parametrize("capture", ["sys", "fd"])
-# def test_capture_empty_stdout(allure_pytest_runner: AllurePytestRunner, capture):
-#     """
-#     >>> import pytest
-#     >>> import allure
-#
-#     >>> @pytest.fixture
-#     ... def fixture(request):
-#     ...     def finalizer():
-#     ...         pass
-#     ...     request.addfinalizer(finalizer)
-#
-#     >>> def test_capture_stdout_example(fixture):
-#     ...     with allure.step("Step"):
-#     ...         pass
-#     """
-#
-#     allure_results = allure_pytest_runner.run_docstring(f"--capture={capture}")
-#
-#     assert_that(
-#         allure_results,
-#         has_property("attachments", empty())
-#     )
-#
-#
-# @pytest.mark.parametrize("logging", [True, False])
-# def test_capture_log(allure_pytest_runner: AllurePytestRunner, logging):
-#     """
-#     >>> import logging
-#     >>> import pytest
-#     >>> import allure
-#
-#     >>> logger = logging.getLogger(__name__)
-#
-#     >>> @pytest.fixture
-#     ... def fixture(request):
-#     ...     logger.info("Start fixture")
-#     ...     def finalizer():
-#     ...         logger.info("Stop fixture")
-#     ...     request.addfinalizer(finalizer)
-#
-#     >>> def test_capture_log_example(fixture):
-#     ...     logger.info("Start test")
-#     ...     with allure.step("Step"):
-#     ...         logger.info("Start step")
-#     """
-#
-#     params = [] if logging else ["-p", "no:logging"]
-#     allure_results = allure_pytest_runner.run_docstring(
-#         "--log-level=INFO",
-#         *params
-#     )
-#
-#     if_logging_ = is_ if logging else is_not
-#
-#     assert_that(
-#         allure_results,
-#         has_property(
-#             "attachments",
-#             all_of(
-#                 if_logging_(has_value(contains_string("Start fixture"))),
-#                 if_logging_(has_value(contains_string("Stop fixture"))),
-#                 if_logging_(has_value(contains_string("Start test"))),
-#                 if_logging_(has_value(contains_string("Start step")))
-#             )
-#         )
-#     )
-#
-#
-# def test_capture_disabled(allure_pytest_runner: AllurePytestRunner):
-#     """
-#     >>> import logging
-#     >>> logger = logging.getLogger(__name__)
-#
-#     >>> def test_capture_disabled_example():
-#     ...     logger.info("Start logging")
-#     ...     #print ("Start printing")
-#
-#     """
-#
-#     allure_results = allure_pytest_runner.run_docstring(
-#         "--log-level=INFO",
-#         "--allure-no-capture"
-#     )
-#
-#     assert_that(
-#         allure_results,
-#         has_property("attachments", empty())
-#     )
+@pytest.mark.parametrize("capture", ["sys", "fd"])
+def test_capture_empty_stdout(allure_pytest_bdd_runner: AllurePytestRunner, capture):
+    feature_content = (
+        """
+        Feature: Basic allure-pytest-bdd usage
+            Scenario: Simple passed example
+                Given the preconditions are satisfied
+                When the action is invoked
+                Then the postconditions are held
+        """
+    )
+    steps_content = (
+        """
+        from pytest_bdd import scenario, given, when, then
+        @scenario("scenario.feature", "Simple passed example")
+        def test_scenario_passes():
+            pass
+
+        @given("the preconditions are satisfied")
+        def given_the_preconditions_are_satisfied():
+            pass
+
+        @when("the action is invoked")
+        def when_the_action_is_invoked():
+            pass
+
+        @then("the postconditions are held")
+        def then_the_postconditions_are_held():
+            pass
+        """
+    )
+
+    allure_results = allure_pytest_bdd_runner.run_pytest(
+        ("scenario.feature", feature_content),
+        steps_content, cli_args=(f"--capture={capture}",)
+    )
+
+    assert_that(
+        allure_results,
+        has_property("attachments", empty())
+    )
+
+
+@pytest.mark.parametrize("logging", [True, False])
+def test_capture_log(allure_pytest_bdd_runner: AllurePytestRunner, logging):
+    feature_content = (
+        """
+        Feature: Basic allure-pytest-bdd usage
+            Scenario: Simple passed example
+                Given the preconditions are satisfied
+                When the action is invoked
+                Then the postconditions are held
+        """
+    )
+    steps_content = (
+        """
+        import logging
+        from pytest_bdd import scenario, given, when, then
+        
+        logger = logging.getLogger(__name__)
+        
+        @scenario("scenario.feature", "Simple passed example")
+        def test_scenario_passes():
+            pass
+
+        @given("the preconditions are satisfied")
+        def given_the_preconditions_are_satisfied():
+            logging.info("Logging from given step")
+
+        @when("the action is invoked")
+        def when_the_action_is_invoked():
+            logging.info("Logging from when step")
+
+        @then("the postconditions are held")
+        def then_the_postconditions_are_held():
+            logging.info("Logging from then step")
+        """
+    )
+
+    params = [] if logging else ["-p", "no:logging"]
+    allure_results = allure_pytest_bdd_runner.run_pytest(
+        ("scenario.feature", feature_content),
+        steps_content, cli_args=("--log-level=INFO", *params)
+    )
+
+    if_logging_ = is_ if logging else is_not
+
+    assert_that(
+        allure_results,
+        has_property(
+            "attachments",
+            all_of(
+                if_logging_(has_value(contains_string("Logging from given step"))),
+                if_logging_(has_value(contains_string("Logging from when step"))),
+                if_logging_(has_value(contains_string("Logging from then step"))),
+            )
+        )
+    )

--- a/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
+++ b/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
@@ -1,0 +1,148 @@
+import pytest
+from hamcrest import assert_that
+from hamcrest import all_of, is_, is_not
+from hamcrest import has_property, has_value
+from hamcrest import contains_string
+from tests.allure_pytest.pytest_runner import AllurePytestRunner
+
+
+@pytest.mark.parametrize("capture", ["sys", "fd", "no"])
+def test_capture_stdout_in_bdd(allure_pytest_bdd_runner: AllurePytestRunner, capture):
+    feature_content = (
+        """
+        Feature: Basic allure-pytest-bdd usage
+            Scenario: Simple passed example
+                Given the preconditions are satisfied
+                When the action is invoked
+                Then the postconditions are held
+        """
+    )
+    steps_content = (
+        """
+        from pytest_bdd import scenario, given, when, then
+        @scenario("scenario.feature", "Simple passed example")
+        def test_scenario_passes():
+            pass
+
+        @given("the preconditions are satisfied")
+        def given_the_preconditions_are_satisfied():
+            print("Print from given step")
+
+        @when("the action is invoked")
+        def when_the_action_is_invoked():
+            print("Print from when step")
+
+        @then("the postconditions are held")
+        def then_the_postconditions_are_held():
+            print("Print from then step")
+        """
+    )
+
+    allure_results = allure_pytest_bdd_runner.run_pytest(
+        ("scenario.feature", feature_content),
+        steps_content, cli_args=(f"--capture={capture}",)
+    )
+    if_pytest_capture_ = is_not if capture == "no" else is_
+
+    assert_that(
+        allure_results,
+        has_property(
+            "attachments",
+            all_of(
+                if_pytest_capture_(has_value(contains_string("Print from given step"))),
+                if_pytest_capture_(has_value(contains_string("Print from when step"))),
+                if_pytest_capture_(has_value(contains_string("Print from then step")))
+            )
+        )
+    )
+
+
+# @pytest.mark.parametrize("capture", ["sys", "fd"])
+# def test_capture_empty_stdout(allure_pytest_runner: AllurePytestRunner, capture):
+#     """
+#     >>> import pytest
+#     >>> import allure
+#
+#     >>> @pytest.fixture
+#     ... def fixture(request):
+#     ...     def finalizer():
+#     ...         pass
+#     ...     request.addfinalizer(finalizer)
+#
+#     >>> def test_capture_stdout_example(fixture):
+#     ...     with allure.step("Step"):
+#     ...         pass
+#     """
+#
+#     allure_results = allure_pytest_runner.run_docstring(f"--capture={capture}")
+#
+#     assert_that(
+#         allure_results,
+#         has_property("attachments", empty())
+#     )
+#
+#
+# @pytest.mark.parametrize("logging", [True, False])
+# def test_capture_log(allure_pytest_runner: AllurePytestRunner, logging):
+#     """
+#     >>> import logging
+#     >>> import pytest
+#     >>> import allure
+#
+#     >>> logger = logging.getLogger(__name__)
+#
+#     >>> @pytest.fixture
+#     ... def fixture(request):
+#     ...     logger.info("Start fixture")
+#     ...     def finalizer():
+#     ...         logger.info("Stop fixture")
+#     ...     request.addfinalizer(finalizer)
+#
+#     >>> def test_capture_log_example(fixture):
+#     ...     logger.info("Start test")
+#     ...     with allure.step("Step"):
+#     ...         logger.info("Start step")
+#     """
+#
+#     params = [] if logging else ["-p", "no:logging"]
+#     allure_results = allure_pytest_runner.run_docstring(
+#         "--log-level=INFO",
+#         *params
+#     )
+#
+#     if_logging_ = is_ if logging else is_not
+#
+#     assert_that(
+#         allure_results,
+#         has_property(
+#             "attachments",
+#             all_of(
+#                 if_logging_(has_value(contains_string("Start fixture"))),
+#                 if_logging_(has_value(contains_string("Stop fixture"))),
+#                 if_logging_(has_value(contains_string("Start test"))),
+#                 if_logging_(has_value(contains_string("Start step")))
+#             )
+#         )
+#     )
+#
+#
+# def test_capture_disabled(allure_pytest_runner: AllurePytestRunner):
+#     """
+#     >>> import logging
+#     >>> logger = logging.getLogger(__name__)
+#
+#     >>> def test_capture_disabled_example():
+#     ...     logger.info("Start logging")
+#     ...     #print ("Start printing")
+#
+#     """
+#
+#     allure_results = allure_pytest_runner.run_docstring(
+#         "--log-level=INFO",
+#         "--allure-no-capture"
+#     )
+#
+#     assert_that(
+#         allure_results,
+#         has_property("attachments", empty())
+#     )


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
Currently allure report for the pytest-bdd framework doesn't include logs, stdout and stderr created during test run. It makes hard to understand what was the root cause of the test failure. In order to fix this I simply added the code from the allure-pytest listener that adds logs, stdout and stderr to the report. Here's a screenshot from the report with logs:

<img width="1439" alt="263251959-119d2b6f-0698-4d86-94fe-6529505b8047" src="https://github.com/allure-framework/allure-python/assets/29369339/d954457e-ab86-4d32-91e0-1f1e4f42d130">

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
