### PR TITLE
Replace version comparison with duck-style checks (fix #802)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,5 @@ exclude =
     ./tests/allure_behave/acceptance/behave_support/background/background_steps.py
 per-file-ignores =
     ./allure-python-commons/src/model2.py:A003
+    ./allure-python-commons/src/types.py:A005
+    ./allure-robotframework/src/listener/types.py:A005

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache commons
         id: commons
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist/
           key: commons-${{ github.sha }}
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -124,7 +124,7 @@ jobs:
 
       - name: Get commons from cache
         id: commons
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist/
           key: commons-${{ github.sha }}
@@ -165,7 +165,7 @@ jobs:
 
       - name: Get commons from cache
         id: commons
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist/
           key: commons-${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/allure-pytest/src/compat.py
+++ b/allure-pytest/src/compat.py
@@ -1,0 +1,34 @@
+"""Provides compatibility with different pytest versions."""
+
+from inspect import signature
+
+__GETFIXTUREDEFS_2ND_PAR_IS_STR = None
+
+
+def getfixturedefs(fixturemanager, name, item):
+    """Calls FixtureManager.getfixturedefs in a way compatible with Python
+    versions before and after the change described in pytest-dev/pytest#11785.
+    """
+    getfixturedefs = fixturemanager.getfixturedefs
+    itemarg = __resolve_getfixturedefs_2nd_arg(getfixturedefs, item)
+    return getfixturedefs(name, itemarg)
+
+
+def __resolve_getfixturedefs_2nd_arg(getfixturedefs, item):
+    # Starting from pytest 8.1, getfixturedefs requires the item itself.
+    # In earlier versions it requires the nodeid string.
+    return item.nodeid if __2nd_parameter_is_str(getfixturedefs) else item
+
+
+def __2nd_parameter_is_str(getfixturedefs):
+    global __GETFIXTUREDEFS_2ND_PAR_IS_STR
+    if __GETFIXTUREDEFS_2ND_PAR_IS_STR is None:
+        __GETFIXTUREDEFS_2ND_PAR_IS_STR =\
+            __get_2nd_parameter_type(getfixturedefs) is str
+    return __GETFIXTUREDEFS_2ND_PAR_IS_STR
+
+
+def __get_2nd_parameter_type(fn):
+    return list(
+        signature(fn).parameters.values()
+    )[1].annotation

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -1,6 +1,5 @@
 import pytest
 import doctest
-from packaging import version
 
 import allure_commons
 from allure_commons.utils import now
@@ -8,6 +7,7 @@ from allure_commons.utils import uuid4
 from allure_commons.utils import represent
 from allure_commons.utils import platform_label
 from allure_commons.utils import host_tag, thread_tag
+from allure_commons.utils import md5
 from allure_commons.reporter import AllureReporter
 from allure_commons.model2 import TestStepResult, TestResult, TestBeforeResult, TestAfterResult
 from allure_commons.model2 import TestResultContainer
@@ -25,7 +25,7 @@ from allure_pytest.utils import get_outcome_status, get_outcome_status_details
 from allure_pytest.utils import get_pytest_report_status
 from allure_pytest.utils import format_allure_link
 from allure_pytest.utils import get_history_id
-from allure_commons.utils import md5
+from allure_pytest.compat import getfixturedefs
 
 
 class AllureListener:
@@ -349,21 +349,11 @@ def _test_fixtures(item):
 
     if hasattr(item, "_request") and hasattr(item._request, "fixturenames"):
         for name in item._request.fixturenames:
-            fixturedefs_pytest = _getfixturedefs(fixturemanager, name, item)
+            fixturedefs_pytest = getfixturedefs(fixturemanager, name, item)
             if fixturedefs_pytest:
                 fixturedefs.extend(fixturedefs_pytest)
 
     return fixturedefs
-
-
-def _getfixturedefs(fixturemanager, name, item):
-    # See pytest-dev/pytest#11785
-    itemarg = item if __is_pytest8_1_or_greater() else item.nodeid
-    return fixturemanager.getfixturedefs(name, itemarg)
-
-
-def __is_pytest8_1_or_greater():
-    return version.parse(pytest.__version__) >= version.parse("8.1")
 
 
 def _exception_brokes_test(exception):

--- a/tests/allure_pytest/acceptance/capture/capture_attach_test.py
+++ b/tests/allure_pytest/acceptance/capture/capture_attach_test.py
@@ -90,10 +90,9 @@ def test_capture_log(allure_pytest_runner: AllurePytestRunner, logging):
     ...         logger.info("Start step")
     """
 
-    params = [] if logging else ["-p", "no:logging"]
+    log_level = "INFO" if logging else "WARNING"
     allure_results = allure_pytest_runner.run_docstring(
-        "--log-level=INFO",
-        *params
+        f"--log-level={log_level}",
     )
 
     if_logging_ = is_ if logging else is_not

--- a/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
+++ b/tests/allure_pytest_bdd/acceptance/capture/capture_attach_test.py
@@ -134,10 +134,10 @@ def test_capture_log(allure_pytest_bdd_runner: AllurePytestRunner, logging):
         """
     )
 
-    params = [] if logging else ["-p", "no:logging"]
+    log_level = "INFO" if logging else "WARNING"
     allure_results = allure_pytest_bdd_runner.run_pytest(
         ("scenario.feature", feature_content),
-        steps_content, cli_args=("--log-level=INFO", *params)
+        steps_content, cli_args=(f"--log-level={log_level}",)
     )
 
     if_logging_ = is_ if logging else is_not


### PR DESCRIPTION
### Context
We currently have two occasions where we need to support backward incompatible changes in test frameworks:

  - Behave 1.2.7 (a pre-release, as for now) replaced `Configuration.tags` with `Configuration.tag_expression`.
  - pytest 8.1 requires a node object to be passed to `FixtureManager.getfixturedefs` instead of the `nodeid` string.

We initially handled those by directly comparing Behave/pytest versions with `packaging.version.parse`.

The solution works fine in allure-pytest since the `packaging` module is a transitive dependency of pytest.

On the other hand, allure-behave crashes with `ModuleNotFoundError` unless `packaging` becomes available either by hand or via some other package (e.g., setuptools). That happens because `packaging` is missing in the `install_requires` metadata of `allure-behave`.

After some discussion, we've decided to abandon version comparison in favor of duck-style checking:

  1. It doesn't require an extra dependency to parse versions.
  2. It's more resistant to future changes (in case the change will be reverted).

### Compatibility with Behave

We now try to access the `tag_expression` attribute first. If the attribute doesn't exist, the `tags` attribute is accessed instead.

### Compatibility with pytest

We're checking the `getfixturedefs` signature. If the second parameter's annotation is `str`, it's provided with `nodeid`. Otherwise, it's provided with the node object itself. The inspection is only done once, on the first call to `getfixturedefs`. The remaining calls use the cached result of the check.

### Additional changes

#### Log capturing tests

Log capturing tests for `allure-pytest` and `allure-pytest-bdd` now raise --log-level to WARNING instead of turning off the `logging` plugin when checking the case of disabled capturing. That prevents the `unrecognized arguments: --log-level=INFO` error when running against pytest 7.

#### CI actions update

As described [here](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), actions that use Node.js version 16 are now deprecated. This PR updates such actions to the latest versions.

#### Flake config adjustment

This PR configs flake8 to ignore the new `A005: the module is shadowing a Python builtin module` rule for already existing modules `allure_commons.types` and `allure-robotframework.listener.types`.


Fixes #802.