### PR TITLE
Fix cache issue with the build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,31 +59,10 @@ jobs:
             allure-python-commons: allure-python-commons/**
             allure-python-commons-test: allure-python-commons-test/**
 
-  commons:
-    name: Build commons
-    runs-on: ubuntu-latest
-    needs: [pytest-changes, other-changes]
-    if: ${{ needs.pytest-changes.outputs.changed == 'true' || needs.other-changes.outputs.packages != '[]' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Cache commons
-        id: commons
-        uses: actions/cache@v4
-        with:
-          path: dist/
-          key: commons-${{ github.sha }}
-
-      - name: Build python commons
-        if: steps.commons.outputs.cache-hit != 'true'
-        run: pip install build &&
-             python -m build allure-python-commons --outdir dist/ &&
-             python -m build allure-python-commons-test --outdir dist/
-
   lint:
     name: Static check
     runs-on: ubuntu-latest
-    needs: [commons, pytest-changes, other-changes]
+    needs: [pytest-changes, other-changes]
     if: ${{ needs.pytest-changes.outputs.changed == 'true' || needs.other-changes.outputs.packages != '[]' }}
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +81,7 @@ jobs:
   test-pytest:
     name: Test allure-pytest
     runs-on: ubuntu-latest
-    needs: [commons, pytest-changes]
+    needs: [pytest-changes]
     if: ${{ needs.pytest-changes.outputs.changed == 'true' }}
     strategy:
       matrix:
@@ -122,16 +101,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Get commons from cache
-        id: commons
-        uses: actions/cache@v4
-        with:
-          path: dist/
-          key: commons-${{ github.sha }}
-
       - name: Install packages
         run: |
-          pip install dist/allure-python-commons*.tar.gz \
+          pip install ./allure-python-commons \
+            ./allure-python-commons-test \
             ./allure-pytest \
             pytest==${{ matrix.pytest-version }} \
             -r ./requirements/testing.txt \
@@ -142,9 +115,9 @@ jobs:
         run: poe tests
 
   test-others:
-    name: Test packages other than allure-pytest
+    name: Test other packages
     runs-on: ubuntu-latest
-    needs: [commons, other-changes]
+    needs: [other-changes]
     if: ${{ needs.other-changes.outputs.packages != '[]' }}
     strategy:
       matrix:
@@ -163,18 +136,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Get commons from cache
-        id: commons
-        uses: actions/cache@v4
-        with:
-          path: dist/
-          key: commons-${{ github.sha }}
-
       - name: Install packages
-        run: pip install dist/allure-python-commons*.tar.gz &&
-             pip install ./${{ matrix.package }} &&
-             pip install -r ./requirements/testing.txt &&
-             pip install -r ./requirements/testing/${{ matrix.package }}.txt
+        run: |
+          pip install ./allure-python-commons \
+            ./allure-python-commons-test \
+            ./${{ matrix.package }} \
+            -r ./requirements/testing.txt \
+            -r ./requirements/testing/${{ matrix.package }}.txt
 
       - name: Test ${{ matrix.package }}
         working-directory: ${{ matrix.package }}


### PR DESCRIPTION
### Context
Starting from version 69.3.0, Setuptools canonicalizes filenames of a source distribution according to [PEP 625](https://peps.python.org/pep-0625/). Notably, all hyphens (`-`) are replaced with underscores (`_`) in the distribution name.

That leads to the following error when installing previously built common packages during a testing job of the build workflow:

```
Run pip install dist/allure-python-commons*.tar.gz \
WARNING: Requirement 'dist/allure-python-commons*.tar.gz' looks like a filename, but the file does not exist
Processing ./dist/allure-python-commons*.tar.gz
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/home/runner/work/allure-python/allure-python/dist/allure-python-commons*.tar.gz'
```

If we run `ls dist` before `pip install,` we see the following content:

```
allure_python_commons-0.1.dev1+g2070930-py3-none-any.whl
allure_python_commons-0.1.dev1+g2070930.tar.gz
allure_python_commons_test-0.1.dev1+g2070930-py3-none-any.whl
allure_python_commons_test-0.1.dev1+g2070930.tar.gz
```

Although a simple fix of the `pip install` command would be enough, I've decided to eliminate caching altogether and replace it with direct installation from the corresponding directory. The caching doesn't save us anything:

```
PS > python -m venv env && ./env/bin/Activate.ps1 &&  measure-command { pip install ./dist/allure_python_commons-2.13.6.dev1+gf185ccc.tar.gz }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 11
Milliseconds      : 705
Ticks             : 117050592
TotalDays         : 0.000135475222222222
TotalHours        : 0.00325140533333333
TotalMinutes      : 0.19508432
TotalSeconds      : 11.7050592
TotalMilliseconds : 11705.0592

PS > rm -rf env && python -m venv env && ./env/bin/Activate.ps1 && measure-command { pip install ./allure-python-commons }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 10
Milliseconds      : 378
Ticks             : 103782877
TotalDays         : 0.000120119070601852
TotalHours        : 0.00288285769444444
TotalMinutes      : 0.172971461666667
TotalSeconds      : 10.3782877
TotalMilliseconds : 10378.2877
```

In fact, it only makes the build longer and more complicated.
