### PR TITLE
Add typehints for step func returning types

### DIFF
--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, Union, overload
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -161,7 +161,15 @@ class Dynamic:
         return Dynamic.label(LabelType.MANUAL, True)
 
 
-def step(title):
+@overload
+def step(title: str) -> "StepContext": ...
+
+
+@overload
+def step(title: _TFunc) -> _TFunc: ...
+
+
+def step(title: Union[str, _TFunc]) -> Union["StepContext", _TFunc]:
     if callable(title):
         return StepContext(title.__name__, {})(title)
     else:


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
There are several issues with using [pyright](https://github.com/microsoft/pyright/) as lsp:
1. When using `allure.step` as a context manager with `with allure.step`, pyright returned the errors: `Object of type "(...) -> object" cannot be used with "with" because it does not implement __exit__`, `Object of type "(...) -> object" cannot be used with "with" because it does not implement __enter__ (lsp)`.
2. When using `allure.step` as a decorator along with `@property`, pyright returned the error: `Argument of type "((self: Self@ClassName) -> SomeReturnType) | object" cannot be assigned to parameter "fget" of type "((Any) -> Any) | None" in function "__init__"`.
3. The most critical part: because pyright could not correctly determine the types, there was no autocompletion available when writing tests using pyright as the LSP.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests / _no unittests needed_

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
