### PR TITLE
Add type hint to allure.step parameters (fixes #828)

### DIFF
--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, Union
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -161,7 +161,7 @@ class Dynamic:
         return Dynamic.label(LabelType.MANUAL, True)
 
 
-def step(title):
+def step(title: Union[str, _TFunc]):
     if callable(title):
         return StepContext(title.__name__, {})(title)
     else:


### PR DESCRIPTION
### Context
Current versions of Pyright flag errors on functions decorated with `@allure.step`, as reported in #828. Adding type hints to `allure.step` fixes this issue.

Tests pass on Python 3.7 and Python 3.13.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
