### PR TITLE
chore(ci): update python versions to test against

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install linting packages
         run: pip install -r ./requirements/linting.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
               - allure-python-commons-test/**
               - tests/*.py
               - tests/allure_pytest/**
+              - .github/workflows/build.yaml
   other-changes:
     name: Collect file changes other than allure-pytest
     runs-on: ubuntu-latest
@@ -38,26 +39,34 @@ jobs:
               - allure-python-commons-test/**
               - tests/*.py
               - tests/allure_behave/**
+              - .github/workflows/build.yaml
             allure-nose2:
               - allure-nose2/**
               - allure-python-commons/**
               - allure-python-commons-test/**
               - tests/*.py
               - tests/allure_nose2/**
+              - .github/workflows/build.yaml
             allure-pytest-bdd:
               - allure-pytest-bdd/**
               - allure-python-commons/**
               - allure-python-commons-test/**
               - tests/*.py
               - tests/allure_pytest_bdd/**
+              - .github/workflows/build.yaml
             allure-robotframework:
               - allure-robotframework/**
               - allure-python-commons/**
               - allure-python-commons-test/**
               - tests/*.py
               - tests/allure_robotframework/**
-            allure-python-commons: allure-python-commons/**
-            allure-python-commons-test: allure-python-commons-test/**
+              - .github/workflows/build.yaml
+            allure-python-commons:
+              - allure-python-commons/**
+              - .github/workflows/build.yaml
+            allure-python-commons-test:
+              - allure-python-commons-test/**
+              - .github/workflows/build.yaml
 
   lint:
     name: Static check

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,11 +85,8 @@ jobs:
     if: ${{ needs.pytest-changes.outputs.changed == 'true' }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         pytest-version: ["7.*", "8.*"]
-        exclude:
-          - python-version: "3.7"
-            pytest-version: "8.*"
     env:
       TEST_TMP: /tmp
       ALLURE_INDENT_OUTPUT: yep
@@ -122,7 +119,7 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJSON(needs.other-changes.outputs.packages) }}
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - package: allure-pytest
     env:


### PR DESCRIPTION
### Context
  - Update the Python matrix of the build workflow to match the versions available in setup-python@5.
  - Update the Python version used to lint the code to 3.13
  - Trigger all tests in case `build.yaml` is changed
