### PR TITLE
chore(commons): tiny fixes of step type checking

### DIFF
--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, TypeVar, Union, overload
+from typing import Any, Callable, TypeVar, overload
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -162,14 +162,16 @@ class Dynamic:
 
 
 @overload
-def step(title: str) -> "StepContext": ...
+def step(title: str) -> "StepContext":
+    ...
 
 
 @overload
-def step(title: _TFunc) -> _TFunc: ...
+def step(title: _TFunc) -> _TFunc:
+    ...
 
 
-def step(title: Union[str, _TFunc]) -> Union["StepContext", _TFunc]:
+def step(title):
     if callable(title):
         return StepContext(title.__name__, {})(title)
     else:

--- a/allure-python-commons/src/_allure.py
+++ b/allure-python-commons/src/_allure.py
@@ -201,7 +201,7 @@ class StepContext:
             with StepContext(self.title.format(*args, **params), params):
                 return func(*a, **kw)
 
-        return impl
+        return impl  # type: ignore
 
 
 class Attach:


### PR DESCRIPTION
### Context
#830 introduces proper typing annotations for `allure.step` via `@typing.overload`.

This PR removes the annotations from the implementation as per [the Python docs](https://docs.python.org/3.8/library/typing.html#typing.overload):

> The @overload-decorated definitions are for the benefit of the type checker only, since they will be overwritten by the non-@overload-decorated definition, **while the latter is used at runtime but should be ignored by a type checker**.

It also disables type checking of the wrapper function returned by `StepContext.__call__` (it can't be typechecked without `ParamSpec`, which is only available in Python 3.10+).
