### PR TITLE
deps(pytest-bdd): pytest-bdd>=5.0.0

### DIFF
--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -27,7 +27,7 @@ setup_requires = [
 
 install_requires = [
     "pytest>=4.5.0",
-    "pytest-bdd>=3.0.0"
+    "pytest-bdd>=5.0.0"
 ]
 
 


### PR DESCRIPTION
### Context
After #845 and #716 allure-pytest-bdd requires pytest-bdd >= 5.0.0
