### PR TITLE
fix(pytest-bdd): compatibility with pytest-bdd 5 and 6

### DIFF
--- a/allure-pytest-bdd/src/utils.py
+++ b/allure-pytest-bdd/src/utils.py
@@ -61,8 +61,8 @@ def get_allure_description(item, feature, scenario):
     if value:
         return value
 
-    feature_description = resolve_description(feature.description)
-    scenario_description = resolve_description(scenario.description)
+    feature_description = extract_description(feature)
+    scenario_description = extract_description(scenario)
     return "\n\n".join(filter(None, [feature_description, scenario_description]))
 
 
@@ -146,7 +146,9 @@ def iter_pytest_tags(item):
             yield LabelType.TAG, mark.name
 
 
-def resolve_description(description):
+def extract_description(obj):
+    description = getattr(obj, "description", None)
+
     if isinstance(description, str):
         return description
 

--- a/tests/allure_pytest_bdd/acceptance/description_test.py
+++ b/tests/allure_pytest_bdd/acceptance/description_test.py
@@ -1,3 +1,4 @@
+import pytest
 from hamcrest import assert_that
 from hamcrest import equal_to
 
@@ -6,6 +7,7 @@ from allure_commons_test.result import has_description
 from allure_commons_test.result import has_description_html
 
 from tests.allure_pytest.pytest_runner import AllurePytestRunner
+from tests.e2e import version_lt
 
 
 def test_description_decorator(allure_pytest_bdd_runner: AllurePytestRunner):
@@ -258,6 +260,10 @@ def test_dynamic_description_html(allure_pytest_bdd_runner: AllurePytestRunner):
     )
 
 
+@pytest.mark.skipif(
+    version_lt("pytest_bdd", 7),
+    reason="Pytest-BDD doesn't support scenario-level descriptions until v7",
+)
 def test_scenario_description(allure_pytest_bdd_runner: AllurePytestRunner):
     feature_content = (
         """
@@ -341,6 +347,10 @@ def test_feature_description(allure_pytest_bdd_runner: AllurePytestRunner):
     )
 
 
+@pytest.mark.skipif(
+    version_lt("pytest_bdd", 7),
+    reason="Pytest-BDD doesn't support scenario-level descriptions until v7",
+)
 def test_feature_and_scenario_description(allure_pytest_bdd_runner: AllurePytestRunner):
     feature_content = (
         """

--- a/tests/allure_pytest_bdd/acceptance/title_test.py
+++ b/tests/allure_pytest_bdd/acceptance/title_test.py
@@ -1,5 +1,6 @@
 from hamcrest import assert_that
 from hamcrest import anything
+from hamcrest import any_of
 
 from allure_commons_test.report import has_test_case
 from allure_commons_test.result import has_title
@@ -7,6 +8,7 @@ from allure_commons_test.result import has_step
 from allure_commons_test.result import with_steps
 
 from tests.allure_pytest.pytest_runner import AllurePytestRunner
+from tests.e2e import version_gte
 
 
 def test_title_decorator(allure_pytest_bdd_runner: AllurePytestRunner):
@@ -517,6 +519,12 @@ def test_step_title_interpolation_priority(allure_pytest_bdd_runner: AllurePytes
         steps_content,
     )
 
+    # before pytest-bdd v6 parsed step args defined fixtures, which may conflict with target fixtures
+    step3_matcher = "Target Fixture" if version_gte("pytest_bdd", 6) else any_of(
+        "Target Fixture",
+        "Lorem Ipsum",
+    )
+
     assert_that(
         allure_results,
         has_test_case(
@@ -524,7 +532,7 @@ def test_step_title_interpolation_priority(allure_pytest_bdd_runner: AllurePytes
             with_steps(
                 anything(),
                 has_title("Lorem Ipsum"),
-                has_title("Target Fixture"),
+                has_title(step3_matcher),
                 has_title("Outline"),
                 has_title("Mark"),
             ),


### PR DESCRIPTION
### Context
Scenario-level descriptions are not supported in Pytest-BDD until version 7. Since we aim to support versions starting from 5, this PR adds some fallbacks when extracting these descriptions.

The PR also disables description tests for Pytest-BDD<7 and makes the step title interpolation test compatible with v5.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
