### PR TITLE
Add support the display of duplicate tag names (fix #832)

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -81,14 +81,21 @@ def format_allure_link(config, url, link_type):
 
 
 def pytest_markers(item):
+    markers = set()
+    builtin_markers = set()
     for keyword in item.keywords.keys():
         if any([keyword.startswith('allure_'), keyword == 'parametrize']):
             continue
-        marker = item.get_closest_marker(keyword)
-        if marker is None:
-            continue
-
-        yield mark_to_str(marker)
+        for marker in item.iter_markers(name=keyword):
+            mark_str = mark_to_str(marker)
+            is_builtin_mark = mark_str.startswith("@pytest.mark.")
+            if is_builtin_mark:
+                if marker.name in builtin_markers:
+                    continue
+                builtin_markers.add(marker.name)
+            if mark_str not in markers:
+                markers.add(mark_str)
+                yield mark_str
 
 
 def mark_to_str(marker):

--- a/tests/allure_pytest/acceptance/label/tag/tag_test.py
+++ b/tests/allure_pytest/acceptance/label/tag/tag_test.py
@@ -35,6 +35,8 @@ def test_show_reserved_pytest_markers_full_decorator(
 
     >>> @pytest.mark.usermark1
     ... @pytest.mark.usermark2
+    ... @pytest.mark.usermark3("comment1")
+    ... @pytest.mark.usermark3("comment2")
     ... @pytest.mark.parametrize("param", ["foo"])
     ... @pytest.mark.skipif(False, reason="reason2")
     ... @pytest.mark.skipif(False, reason="reason1")
@@ -50,6 +52,8 @@ def test_show_reserved_pytest_markers_full_decorator(
             "test_show_reserved_pytest_markers_full_decorator_example[foo]",
             has_tag("usermark1"),
             has_tag("usermark2"),
+            has_tag("usermark3('comment1')"),
+            has_tag("usermark3('comment2')"),
             has_tag("@pytest.mark.skipif(False, reason='reason1')"),
             not_(
                 has_tag("@pytest.mark.skipif(False, reason='reason2')")


### PR DESCRIPTION
### Context
* Fix the issue #832
* All user-defined markers (e.g. `case_id`) will be fully collected according to the described problem
* Only the closest built-in pytest markers (e.g. `skipif`) will still be collected according to the existing tests
* Modified `pytest_markers()` method and corresponding test `test_show_reserved_pytest_markers_full_decorator()`

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

_P.S.: This is my first open source contribution. I'm happy to improve it if there's anything that needs to be changed or improved. Thanks for reviewing!_

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
