### PR TITLE
Mark parent step as failed if child step failed with soft check (fix #827)

### DIFF
--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -23,6 +23,7 @@ from allure_pytest.utils import allure_suite_labels
 from allure_pytest.utils import get_status, get_status_details
 from allure_pytest.utils import get_outcome_status, get_outcome_status_details
 from allure_pytest.utils import get_pytest_report_status
+from allure_pytest.utils import sync_steps_statuses
 from allure_pytest.utils import format_allure_link
 from allure_pytest.utils import get_history_id
 from allure_pytest.compat import getfixturedefs
@@ -226,6 +227,9 @@ class AllureListener:
             if test_result.status == Status.PASSED:
                 test_result.status = status
                 test_result.statusDetails = status_details
+            has_failed_steps = sync_steps_statuses(test_result.steps)
+            if has_failed_steps and not hasattr(report, "wasxfail"):
+                test_result.status = Status.FAILED
 
         if report.when == 'teardown':
             if status in (Status.FAILED, Status.BROKEN) and test_result.status == Status.PASSED:

--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -184,6 +184,17 @@ def get_pytest_report_status(pytest_report):
             return status
 
 
+def sync_steps_statuses(steps):
+    any_failed = False
+    for step in steps:
+        if step.steps and sync_steps_statuses(step.steps):
+            if step.status != Status.SKIPPED:
+                step.status = Status.FAILED
+        if step.status == Status.FAILED:
+            any_failed = True
+    return any_failed
+
+
 def get_history_id(full_name, parameters, original_values):
     return md5(
         full_name,


### PR DESCRIPTION
### Context
* Fix the issue #827
* Added `sync_steps_statuses()` method to synchronise the status for the parent step based on the status of the child steps. This method returns `True` if at least one nested step has failed — allowing the parent step or the test itself to be marked as failed
* Added test `test_pytest_fail_in_nested_step_with_soft_check()` to validate the described test scenario
* Here is an example of allure report after the fix:
<img src="https://github.com/user-attachments/assets/ea0cee07-a9d9-4490-9994-f94f293b6bbd" width="400">

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
