### PR TITLE
fix(behave): add cleanup; fix invalid call from AllureHooks

### DIFF
--- a/allure-behave/src/formatter.py
+++ b/allure-behave/src/formatter.py
@@ -12,10 +12,10 @@ class AllureFormatter(Formatter):
         super(AllureFormatter, self).__init__(stream_opener, config)
 
         self.listener = AllureListener(config)
-        file_logger = AllureFileLogger(self.stream_opener.name)
+        self.file_logger = AllureFileLogger(self.stream_opener.name)
 
         allure_commons.plugin_manager.register(self.listener)
-        allure_commons.plugin_manager.register(file_logger)
+        allure_commons.plugin_manager.register(self.file_logger)
 
         self.testplan = get_testplan()
 
@@ -44,6 +44,15 @@ class AllureFormatter(Formatter):
 
     def eof(self):
         self.listener.stop_feature()
+
+    def close(self):
+        try:
+            super().close()
+        finally:
+            for plugin in [self.file_logger, self.listener]:
+                name = allure_commons.plugin_manager.get_name(plugin)
+                if allure_commons.plugin_manager.has_plugin(name):
+                    allure_commons.plugin_manager.unregister(name=name)
 
     def close_stream(self):
         self.listener.stop_session()

--- a/allure-behave/src/hooks.py
+++ b/allure-behave/src/hooks.py
@@ -6,6 +6,7 @@ from allure_behave.listener import AllureListener
 from behave.configuration import Configuration
 
 HOOKS = [
+    "after_all",
     "before_feature",
     "after_feature",
     "before_scenario",
@@ -42,12 +43,22 @@ def allure_report(result_dir="allure_results"):
 class AllureHooks:
     def __init__(self, result_dir):
         self.listener = AllureListener(Configuration())
+        self.plugins = []
 
         if not hasattr(_storage, 'file_logger'):
-            _storage.file_logger = AllureFileLogger(result_dir)
-            allure_commons.plugin_manager.register(_storage.file_logger)
+            logger = AllureFileLogger(result_dir)
+            _storage.file_logger = logger
+            allure_commons.plugin_manager.register(logger)
+            self.plugins.append(logger)
 
         allure_commons.plugin_manager.register(self.listener)
+        self.plugins.append(self.listener)
+
+    def after_all(self, context):
+        for plugin in self.plugins:
+            name = allure_commons.plugin_manager.get_name(plugin)
+            if allure_commons.plugin_manager.has_plugin(name):
+                allure_commons.plugin_manager.unregister(name=name)
 
     def before_feature(self, context, feature):
         self.listener.start_file()

--- a/allure-behave/src/hooks.py
+++ b/allure-behave/src/hooks.py
@@ -50,7 +50,7 @@ class AllureHooks:
         allure_commons.plugin_manager.register(self.listener)
 
     def before_feature(self, context, feature):
-        self.listener.start_feature()
+        self.listener.start_file()
 
     def after_feature(self, context, feature):
         self.listener.stop_feature()

--- a/tests/allure_behave/defects/issue858_test.py
+++ b/tests/allure_behave/defects/issue858_test.py
@@ -1,0 +1,38 @@
+import allure
+import shlex
+
+from tests.allure_behave.behave_runner import AllureBehaveRunner
+from ...e2e import allure_file_context
+
+from behave import __main__ as runner
+
+
+@allure.issue("858")
+def test_test_results_leak(behave_runner: AllureBehaveRunner):
+    feature_path = behave_runner.pytester.makefile(
+        ".feature",
+        (
+            """
+            Feature: Foo
+              Scenario: Bar
+                Given baz
+            """
+        ),
+    )
+    behave_runner.pytester.makefile(
+        ".py",
+        **{"steps/steps": "given('baz')(lambda *_: None)"},
+    )
+
+    args = shlex.join([
+        feature_path.name,
+        "-f", "allure_behave.formatter:AllureFormatter",
+        "-o", "allure-results",
+        "--no-summary",
+    ])
+
+    with allure_file_context("allure-results") as context:
+        runner.main(args)
+        runner.main(args)
+
+    assert len(context.allure_results.test_cases) == 2


### PR DESCRIPTION
### Context
At the beginning of the test run, Allure Behave registers a file logger that writes test results on disk. Due to a lack of cleanup, when Behave is run in-process, those loggers keep accumulating, which increases the number of written files exponentially.

The PR adds the cleanup for the `AllureFormatter` and `AllureHooks`, which fixes the issue.

#### Extra changes

  - fix invalid function call in `AllureHooks.before_feature`: it should call `AllureListener.start_file`, not `AllureListener.start_feature`

Fixes #629
Fixes #858

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
