### PR TITLE
Don't convert built-in (reserved) pytest markers to allure tags (fix #817)

### DIFF
--- a/allure-pytest/src/utils.py
+++ b/allure-pytest/src/utils.py
@@ -1,6 +1,6 @@
 import pytest
 from itertools import chain, islice
-from allure_commons.utils import represent, SafeFormatter, md5
+from allure_commons.utils import SafeFormatter, md5
 from allure_commons.utils import format_exception, format_traceback
 from allure_commons.model2 import Status
 from allure_commons.model2 import StatusDetails

--- a/tests/allure_pytest/acceptance/label/tag/tag_test.py
+++ b/tests/allure_pytest/acceptance/label/tag/tag_test.py
@@ -5,13 +5,15 @@ from allure_commons_test.report import has_test_case
 from allure_commons_test.label import has_tag
 
 
-def test_pytest_marker(allure_pytest_runner: AllurePytestRunner):
+def test_pytest_simple_markers_are_converted_to_allure_tags(
+        allure_pytest_runner: AllurePytestRunner
+):
     """
     >>> import pytest
 
     >>> @pytest.mark.cool
     ... @pytest.mark.stuff
-    ... def test_pytest_marker_example():
+    ... def test_pytest_simple_markers_are_converted_to_allure_tags_example():
     ...     pass
     """
 
@@ -20,15 +22,63 @@ def test_pytest_marker(allure_pytest_runner: AllurePytestRunner):
     assert_that(
         allure_results,
         has_test_case(
-            "test_pytest_marker_example",
+            "test_pytest_simple_markers_are_converted_to_allure_tags_example",
             has_tag("cool"),
             has_tag("stuff")
         )
     )
 
 
-def test_show_reserved_pytest_markers_full_decorator(
-    allure_pytest_runner: AllurePytestRunner
+def test_pytest_marker_with_args_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
+    """
+    >>> import pytest
+
+    >>> @pytest.mark.marker('cool', 'stuff')
+    ... def test_pytest_marker_with_args_is_not_converted_to_allure_tag_example():
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_pytest_marker_with_args_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("marker('cool', 'stuff')")
+            )
+        )
+    )
+
+
+def test_pytest_marker_with_kwargs_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
+    """
+    >>> import pytest
+
+    >>> @pytest.mark.marker(stuff='cool')
+    ... def test_pytest_marker_with_kwargs_is_not_converted_to_allure_tag_example():
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_pytest_marker_with_kwargs_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("marker(stuff='cool')")
+            )
+        )
+    )
+
+
+def test_pytest_multiple_simple_and_reserved_markers_to_allure_tags(
+        allure_pytest_runner: AllurePytestRunner
 ):
     """
     >>> import pytest
@@ -38,7 +88,7 @@ def test_show_reserved_pytest_markers_full_decorator(
     ... @pytest.mark.parametrize("param", ["foo"])
     ... @pytest.mark.skipif(False, reason="reason2")
     ... @pytest.mark.skipif(False, reason="reason1")
-    ... def test_show_reserved_pytest_markers_full_decorator_example(param):
+    ... def test_pytest_multiple_simple_and_reserved_markers_to_allure_tags_example(param):
     ...     pass
     """
 
@@ -47,26 +97,126 @@ def test_show_reserved_pytest_markers_full_decorator(
     assert_that(
         allure_results,
         has_test_case(
-            "test_show_reserved_pytest_markers_full_decorator_example[foo]",
+            "test_pytest_multiple_simple_and_reserved_markers_to_allure_tags_example[foo]",
             has_tag("usermark1"),
             has_tag("usermark2"),
-            has_tag("@pytest.mark.skipif(False, reason='reason1')"),
             not_(
-                has_tag("@pytest.mark.skipif(False, reason='reason2')")
+                has_tag("skipif(False, reason='reason1')")
             ),
             not_(
-                has_tag("@pytest.mark.parametrize('param', ['foo'])")
+                has_tag("skipif(False, reason='reason2')")
+            ),
+            not_(
+                has_tag("parametrize('param', ['foo'])")
             )
         )
     )
 
 
-def test_pytest_xfail_marker(allure_pytest_runner: AllurePytestRunner):
+def test_pytest_reserved_marker_usefixtures_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
+    """
+    >>> import pytest
+
+    >>> @pytest.mark.usefixtures('test_fixture')
+    ... def test_pytest_reserved_marker_usefixtures_is_not_converted_to_allure_tag_example():
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_pytest_reserved_marker_usefixtures_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("usefixtures('test_fixture')")
+            )
+        )
+    )
+
+
+def test_pytest_reserved_marker_filterwarnings_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
+    """
+    >>> import pytest
+
+    >>> @pytest.mark.filterwarnings('ignore:val')
+    ... def test_pytest_reserved_marker_filterwarnings_is_not_converted_to_allure_tag_example():
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_pytest_reserved_marker_filterwarnings_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("filterwarnings('ignore:val')")
+            )
+        )
+    )
+
+
+def test_pytest_reserved_marker_skip_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
+    """
+    >>> import pytest
+
+    >>> @pytest.mark.skip(reason='reason')
+    ... def test_pytest_reserved_marker_skip_is_not_converted_to_allure_tag_example():
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_pytest_reserved_marker_skip_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("skip(reason='reason')")
+            )
+        )
+    )
+
+
+def test_pytest_reserved_marker_skipif_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
+    """
+    >>> import pytest
+
+    >>> @pytest.mark.skipif(False, reason='reason')
+    ... def test_pytest_reserved_marker_skipif_is_not_converted_to_allure_tag_example():
+    ...     pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_pytest_reserved_marker_skipif_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("skipif(False, reason='reason')")
+            )
+        )
+    )
+
+
+def test_pytest_reserved_marker_xfail_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
+):
     """
     >>> import pytest
 
     >>> @pytest.mark.xfail(reason='this is unexpect pass')
-    ... def test_pytest_xfail_marker_example():
+    ... def test_pytest_reserved_marker_xfail_is_not_converted_to_allure_tag_example():
     ...     pass
     """
 
@@ -75,60 +225,22 @@ def test_pytest_xfail_marker(allure_pytest_runner: AllurePytestRunner):
     assert_that(
         allure_results,
         has_test_case(
-            "test_pytest_xfail_marker_example",
-            has_tag("@pytest.mark.xfail(reason='this is unexpect pass')")
+            "test_pytest_reserved_marker_xfail_is_not_converted_to_allure_tag_example",
+            not_(
+                has_tag("xfail(reason='this is unexpect pass')")
+            )
         )
     )
 
 
-def test_pytest_marker_with_args(allure_pytest_runner: AllurePytestRunner):
-    """
-    >>> import pytest
-
-    >>> @pytest.mark.marker('cool', 'stuff')
-    ... def test_pytest_marker_with_args_example():
-    ...     pass
-    """
-
-    allure_results = allure_pytest_runner.run_docstring()
-
-    assert_that(
-        allure_results,
-        has_test_case(
-            "test_pytest_marker_with_args_example",
-            has_tag("marker('cool', 'stuff')")
-        )
-    )
-
-
-def test_pytest_marker_with_kwargs(allure_pytest_runner: AllurePytestRunner):
-    """
-    >>> import pytest
-
-    >>> @pytest.mark.marker(stuff='cool')
-    ... def test_pytest_marker_with_kwargs_example():
-    ...     pass
-    """
-
-    allure_results = allure_pytest_runner.run_docstring()
-
-    assert_that(
-        allure_results,
-        has_test_case(
-            "test_pytest_marker_with_kwargs_example",
-            has_tag("marker(stuff='cool')")
-        )
-    )
-
-
-def test_pytest_marker_with_kwargs_native_encoding(
-    allure_pytest_runner: AllurePytestRunner
+def test_pytest_reserved_marker_parametrize_is_not_converted_to_allure_tag(
+        allure_pytest_runner: AllurePytestRunner
 ):
     """
     >>> import pytest
 
-    >>> @pytest.mark.marker(stuff='я')
-    ... def test_pytest_marker_with_kwargs_native_encoding_example():
+    >>> @pytest.mark.parametrize("param", ["foo"])
+    ... def test_pytest_reserved_marker_parametrize_is_not_converted_to_allure_tag_example(param):
     ...     pass
     """
 
@@ -137,20 +249,23 @@ def test_pytest_marker_with_kwargs_native_encoding(
     assert_that(
         allure_results,
         has_test_case(
-            "test_pytest_marker_with_kwargs_native_encoding_example",
-            has_tag("marker(stuff='я')")
+            "test_pytest_reserved_marker_parametrize_is_not_converted_to_allure_tag_example[foo]",
+            not_(
+                has_tag("parametrize('param', ['foo'])")
+            )
         )
     )
 
 
-def test_pytest_marker_with_kwargs_utf_encoding(
-    allure_pytest_runner: AllurePytestRunner
+def test_pytest_simple_markers_utf_encoding_are_converted_to_allure_tags(
+        allure_pytest_runner: AllurePytestRunner
 ):
     """
     >>> import pytest
 
-    >>> @pytest.mark.marker(stuff='я')
-    ... def test_pytest_marker_with_kwargs_utf_encoding_example():
+    >>> @pytest.mark.классная
+    >>> @pytest.mark.штука
+    ... def test_pytest_simple_markers_utf_encoding_are_converted_to_allure_tags_example():
     ...     pass
     """
 
@@ -159,7 +274,8 @@ def test_pytest_marker_with_kwargs_utf_encoding(
     assert_that(
         allure_results,
         has_test_case(
-            "test_pytest_marker_with_kwargs_utf_encoding_example",
-            has_tag("marker(stuff='я')")
+            "test_pytest_simple_markers_utf_encoding_are_converted_to_allure_tags_example",
+            has_tag("классная"),
+            has_tag("штука")
         )
     )

--- a/tests/allure_pytest/acceptance/label/tag/tag_test.py
+++ b/tests/allure_pytest/acceptance/label/tag/tag_test.py
@@ -1,4 +1,4 @@
-from hamcrest import assert_that, not_
+from hamcrest import assert_that, not_, anything
 from tests.allure_pytest.pytest_runner import AllurePytestRunner
 
 from allure_commons_test.report import has_test_case
@@ -47,7 +47,7 @@ def test_pytest_marker_with_args_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_marker_with_args_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("marker('cool', 'stuff')")
+                has_tag(anything())
             )
         )
     )
@@ -71,43 +71,7 @@ def test_pytest_marker_with_kwargs_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_marker_with_kwargs_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("marker(stuff='cool')")
-            )
-        )
-    )
-
-
-def test_pytest_multiple_simple_and_reserved_markers_to_allure_tags(
-        allure_pytest_runner: AllurePytestRunner
-):
-    """
-    >>> import pytest
-
-    >>> @pytest.mark.usermark1
-    ... @pytest.mark.usermark2
-    ... @pytest.mark.parametrize("param", ["foo"])
-    ... @pytest.mark.skipif(False, reason="reason2")
-    ... @pytest.mark.skipif(False, reason="reason1")
-    ... def test_pytest_multiple_simple_and_reserved_markers_to_allure_tags_example(param):
-    ...     pass
-    """
-
-    allure_results = allure_pytest_runner.run_docstring()
-
-    assert_that(
-        allure_results,
-        has_test_case(
-            "test_pytest_multiple_simple_and_reserved_markers_to_allure_tags_example[foo]",
-            has_tag("usermark1"),
-            has_tag("usermark2"),
-            not_(
-                has_tag("skipif(False, reason='reason1')")
-            ),
-            not_(
-                has_tag("skipif(False, reason='reason2')")
-            ),
-            not_(
-                has_tag("parametrize('param', ['foo'])")
+                has_tag(anything())
             )
         )
     )
@@ -131,7 +95,7 @@ def test_pytest_reserved_marker_usefixtures_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_reserved_marker_usefixtures_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("usefixtures('test_fixture')")
+                has_tag(anything())
             )
         )
     )
@@ -155,7 +119,7 @@ def test_pytest_reserved_marker_filterwarnings_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_reserved_marker_filterwarnings_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("filterwarnings('ignore:val')")
+                has_tag(anything())
             )
         )
     )
@@ -179,7 +143,7 @@ def test_pytest_reserved_marker_skip_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_reserved_marker_skip_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("skip(reason='reason')")
+                has_tag(anything())
             )
         )
     )
@@ -203,7 +167,7 @@ def test_pytest_reserved_marker_skipif_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_reserved_marker_skipif_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("skipif(False, reason='reason')")
+                has_tag(anything())
             )
         )
     )
@@ -227,7 +191,7 @@ def test_pytest_reserved_marker_xfail_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_reserved_marker_xfail_is_not_converted_to_allure_tag_example",
             not_(
-                has_tag("xfail(reason='this is unexpect pass')")
+                has_tag(anything())
             )
         )
     )
@@ -251,31 +215,7 @@ def test_pytest_reserved_marker_parametrize_is_not_converted_to_allure_tag(
         has_test_case(
             "test_pytest_reserved_marker_parametrize_is_not_converted_to_allure_tag_example[foo]",
             not_(
-                has_tag("parametrize('param', ['foo'])")
+                has_tag(anything())
             )
-        )
-    )
-
-
-def test_pytest_simple_markers_utf_encoding_are_converted_to_allure_tags(
-        allure_pytest_runner: AllurePytestRunner
-):
-    """
-    >>> import pytest
-
-    >>> @pytest.mark.классная
-    >>> @pytest.mark.штука
-    ... def test_pytest_simple_markers_utf_encoding_are_converted_to_allure_tags_example():
-    ...     pass
-    """
-
-    allure_results = allure_pytest_runner.run_docstring()
-
-    assert_that(
-        allure_results,
-        has_test_case(
-            "test_pytest_simple_markers_utf_encoding_are_converted_to_allure_tags_example",
-            has_tag("классная"),
-            has_tag("штука")
         )
     )

--- a/tests/allure_pytest/externals/pytest_rerunfailures/pytest_rerunfailures_test.py
+++ b/tests/allure_pytest/externals/pytest_rerunfailures/pytest_rerunfailures_test.py
@@ -65,6 +65,6 @@ def test_separate_result_for_each_rerun(rerunfailures_runner: AllurePytestRunner
 
     assert len(output.test_cases) == 2
     assert __count_labels(output.test_cases[0], "suite") == 1
-    assert __count_labels(output.test_cases[0], "tag") == 1
+    assert __count_labels(output.test_cases[0], "tag") == 0
     assert __count_labels(output.test_cases[1], "suite") == 1
-    assert __count_labels(output.test_cases[1], "tag") == 1
+    assert __count_labels(output.test_cases[1], "tag") == 0


### PR DESCRIPTION
### Context
* Fix the issue #817
* **Code changes:**
    * The `pytest_markers(item)` method in `utils.py` has been simplified - now only "simple" user-defined pytest markers are converted to allure tags. Built-in (reserved) markers (e.g. `skip`, `xfail`, etc.) are now ignored. The approach was taken from [allure-pytest-bdd](https://github.com/allure-framework/allure-python/blob/04a96551d98a94a258e3137c62859abcf92ca845/allure-pytest-bdd/src/utils.py#L143) implementation

* **Unit tests changes:**
    * Existing tests in `tag_test.py` have been updated, new tests have been added for each built-in (reserved) marker to verify they are ignored
    * Renamed both the update and the new tests to make their purpose clearer
    * Removed `test_pytest_marker_with_kwargs_native_encoding` as a duplicate of `test_pytest_marker_with_kwargs_utf_encoding` - they looked identical
    * Updated the affected test in `pytest_rerunfailures_test.py` accordingly

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
