### PR TITLE
fix(pytest): can't change a fixture's title in pytest 8.4 or later

### DIFF
--- a/allure-pytest/src/helper.py
+++ b/allure-pytest/src/helper.py
@@ -10,7 +10,9 @@ class AllureTitleHelper:
     def decorate_as_title(self, test_title):
         def decorator(func):
             # pytest.fixture wraps function, so we need to get it directly
-            if getattr(func, '__pytest_wrapped__', None):
+            if hasattr(func, "_get_wrapped_function"):  # pytest >= 8.4
+                function = func._get_wrapped_function()
+            elif hasattr(func, "__pytest_wrapped__"):  # pytest < 8.4
                 function = func.__pytest_wrapped__.obj
             else:
                 function = func


### PR DESCRIPTION
### Context

Starting from pytest 8.4, fixtures are represented as instances of the `_pytest.fixtures.FixtureFunctionDefinition` class. See pytest-dev/pytest#12473 for more details.

This PR adapts Allure Pytest to take this into account when attaching a custom name to a function using the `@allure.title` decorator.


