### PR TITLE
fix(pytest): properly include nested classes in fullName, historyId, testCaseId, and subSuite

### DIFF
--- a/allure-python-commons-test/src/result.py
+++ b/allure-python-commons-test/src/result.py
@@ -224,3 +224,7 @@ def with_mode(mode):
 
 def has_history_id(matcher=None):
     return has_entry('historyId', matcher or anything())
+
+
+def has_full_name(matcher):
+    return has_entry("fullName", matcher)

--- a/tests/allure_pytest/defects/issue868_test.py
+++ b/tests/allure_pytest/defects/issue868_test.py
@@ -1,0 +1,47 @@
+import allure
+from hamcrest import assert_that, is_not
+from tests.allure_pytest.pytest_runner import AllurePytestRunner
+
+from allure_commons_test.report import has_test_case
+from allure_commons_test.result import has_full_name
+from allure_commons_test.label import has_sub_suite
+
+
+@allure.issue("868", name="Issue 868")
+def test_nested_class_affects_fullname_and_subsuite(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> class TestFoo:
+    ...     class TestBar:
+    ...         def test_bar(self):
+    ...             pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring(filename="foo_test.py")
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_bar",
+            has_full_name("foo_test.TestFoo.TestBar#test_bar"),
+            has_sub_suite("TestFoo > TestBar"),
+        ),
+    )
+
+
+@allure.issue("868", name="Issue 868")
+def test_nested_class_affects_testcaseid_and_historyid(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> class TestFoo:
+    ...     class TestFoo:
+    ...         def test_foo(self):
+    ...             pass
+    ...     def test_foo(self):
+    ...         pass
+    """
+
+    allure_results = allure_pytest_runner.run_docstring(filename="foo_test.py")
+    test_case_id1, test_case_id2 = [tc["testCaseId"] for tc in allure_results.test_cases]
+    history_id1, history_id2 = [tc["historyId"] for tc in allure_results.test_cases]
+
+    assert_that(test_case_id1, is_not(test_case_id2))
+    assert_that(history_id1, is_not(history_id2))


### PR DESCRIPTION
### Context
Pytest supports nested test classes:

```python
class TestFoo:
    class TestBar:
        def test_baz(self):
            pass
```

Currently, Allure Pytest incorrectly assumes there is zero or one test class in every given `nodeid` when calculating `fullName` and `subSuite`. Since the test above has nodeid `module_test.py::TestFoo::TestBar::test_baz`, the calculations become invalid.

Given that `testCaseId` and `historyId` depend on `fullName`, these properties are calculated incorrectly as well.

The PR fixes how Allure Pytest handles such cases:

  - All test classes are now included in `fullName` (joined with `.`).
  - All test classes are now included in the value of the `subSuite` label (joined with ` > `).

Fixes #868.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
