### PR TITLE
Add zip attachment type

### DIFF
--- a/allure-python-commons/src/allure_commons/types.py
+++ b/allure-python-commons/src/allure_commons/types.py
@@ -50,6 +50,7 @@ class AttachmentType(Enum):
     JSON = ("application/json", "json")
     YAML = ("application/yaml", "yaml")
     PCAP = ("application/vnd.tcpdump.pcap", "pcap")
+    ZIP = ("application/zip", "zip")
 
     PNG = ("image/png", "png")
     JPG = ("image/jpg", "jpg")


### PR DESCRIPTION
### Context

- Closes #442

Provides an attachment type for zip files.

```python
import allure

def test_function():
    allure.attach.file(
        source="file.zip",
        attachment_type=allure.attachment_type.ZIP,
    )
```

This is currently mitigated by specifying the `extension` directly as `"zip"`. Allure correctly infers the [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) as `"application/zip"` while generating the reports.

```python
import allure

def test_function():
    allure.attach.file(
        source="file.zip",
        extension="zip",
    )
```

<img width="1806" height="168" alt="image" src="https://github.com/user-attachments/assets/97fd5160-e566-4d21-a77f-1b3365b937ee" />

Specifying the `name` directly is also an option to ensure the attachment retains the appropriate zip file extension. Though this replaces the unique attachment name. To render the media type within the report, either specify the type directly through `attachment_type` or specify the `extension` as above.

```python
import allure

def test_function():
    allure.attach.file(
        source="file.zip",
        name="file.zip",
        attachment_type="application/zip",
    )
```

<img width="893" height="90" alt="image" src="https://github.com/user-attachments/assets/48bd365e-946a-4290-9181-028954953fcc" />

#### Checklist

- [x] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2