### PR TITLE
chore(ci): test python 3.14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install linting packages
         run: pip install -r ./requirements/linting.txt
@@ -97,7 +97,7 @@ jobs:
     if: ${{ needs.pytest-changes.outputs.changed == 'true' }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         pytest-version: ["7.*", "8.*", "9.*"]
         exclude:
           # pytest 9 supports Python >= 3.10
@@ -137,7 +137,7 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJSON(needs.other-changes.outputs.packages) }}
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - package: allure-pytest
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install linting packages
         run: pip install -r ./requirements/linting.txt
@@ -97,7 +97,7 @@ jobs:
     if: ${{ needs.pytest-changes.outputs.changed == 'true' }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         pytest-version: ["7.*", "8.*"]
     env:
       TEST_TMP: /tmp
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         package: ${{ fromJSON(needs.other-changes.outputs.packages) }}
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - package: allure-pytest
     env:

--- a/allure-behave/setup.py
+++ b/allure-behave/setup.py
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 setup_requires = [

--- a/allure-nose2/setup.py
+++ b/allure-nose2/setup.py
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 setup_requires = [

--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 setup_requires = [

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 setup_requires = [

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 setup_requires = [

--- a/allure-python-commons-test/setup.py
+++ b/allure-python-commons-test/setup.py
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 install_requires = [

--- a/allure-python-commons/setup.py
+++ b/allure-python-commons/setup.py
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 install_requires = [

--- a/allure-robotframework/setup.py
+++ b/allure-robotframework/setup.py
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 setup_requires = [


### PR DESCRIPTION
### Context

- Update the Python matrix of the build workflow to test with the latest Python version, [3.14](https://docs.python.org/3/whatsnew/3.14.html) - released 7 October 2025
- Update package classifiers to declare Python 3.14 support.
- Update the Python version used to lint the code to 3.14.