### PR TITLE
fix(commons): Drop Python 3.6 and 3.7 support

### DIFF
--- a/allure-behave/setup.py
+++ b/allure-behave/setup.py
@@ -62,7 +62,7 @@ def main():
         package_dir={"allure_behave": "src"},
         setup_requires=setup_requires,
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 if __name__ == "__main__":

--- a/allure-behave/setup.py
+++ b/allure-behave/setup.py
@@ -61,7 +61,8 @@ def main():
         packages=["allure_behave"],
         package_dir={"allure_behave": "src"},
         setup_requires=setup_requires,
-        install_requires=install_requires
+        install_requires=install_requires,
+        python_requires=">=3.7",
     )
 
 if __name__ == "__main__":

--- a/allure-behave/src/formatter.py
+++ b/allure-behave/src/formatter.py
@@ -9,7 +9,7 @@ from allure_behave.utils import is_planned_scenario
 
 class AllureFormatter(Formatter):
     def __init__(self, stream_opener, config):
-        super(AllureFormatter, self).__init__(stream_opener, config)
+        super().__init__(stream_opener, config)
 
         self.listener = AllureListener(config)
         self.file_logger = AllureFileLogger(self.stream_opener.name)

--- a/allure-nose2/setup.py
+++ b/allure-nose2/setup.py
@@ -59,7 +59,8 @@ def main():
         packages=["allure_nose2"],
         package_dir={"allure_nose2": "src"},
         setup_requires=setup_requires,
-        install_requires=install_requires
+        install_requires=install_requires,
+        python_requires=">=3.7",
     )
 
 

--- a/allure-nose2/setup.py
+++ b/allure-nose2/setup.py
@@ -60,7 +60,7 @@ def main():
         package_dir={"allure_nose2": "src"},
         setup_requires=setup_requires,
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 

--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -63,7 +63,8 @@ def main():
         package_dir={"allure_pytest_bdd": "src"},
         entry_points={"pytest11": ["allure_pytest_bdd = allure_pytest_bdd.plugin"]},
         setup_requires=setup_requires,
-        install_requires=install_requires
+        install_requires=install_requires,
+        python_requires=">=3.7",
     )
 
 

--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -64,7 +64,7 @@ def main():
         entry_points={"pytest11": ["allure_pytest_bdd = allure_pytest_bdd.plugin"]},
         setup_requires=setup_requires,
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -63,7 +63,8 @@ def main():
         package_dir={"allure_pytest": "src"},
         entry_points={"pytest11": ["allure_pytest = allure_pytest.plugin"]},
         setup_requires=setup_requires,
-        install_requires=install_requires
+        install_requires=install_requires,
+        python_requires=">=3.7",
     )
 
 if __name__ == "__main__":

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -76,7 +76,8 @@ def main():
         package_dir={"allure_pytest": "src"},
         entry_points={"pytest11": ["allure_pytest = allure_pytest.plugin"]},
         setup_requires=setup_requires,
-        install_requires=install_requires
+        install_requires=install_requires,
+        python_requires=">=3.7",
     )
 
 if __name__ == "__main__":

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -77,7 +77,7 @@ def main():
         entry_points={"pytest11": ["allure_pytest = allure_pytest.plugin"]},
         setup_requires=setup_requires,
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 if __name__ == "__main__":

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -64,7 +64,7 @@ def main():
         entry_points={"pytest11": ["allure_pytest = allure_pytest.plugin"]},
         setup_requires=setup_requires,
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 if __name__ == "__main__":

--- a/allure-python-commons-test/setup.py
+++ b/allure-python-commons-test/setup.py
@@ -51,7 +51,7 @@ def main():
         packages=["allure_commons_test"],
         package_dir={"allure_commons_test": "src"},
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 if __name__ == "__main__":

--- a/allure-python-commons-test/setup.py
+++ b/allure-python-commons-test/setup.py
@@ -50,7 +50,8 @@ def main():
         long_description_content_type="text/markdown",
         packages=["allure_commons_test"],
         package_dir={"allure_commons_test": "src"},
-        install_requires=install_requires
+        install_requires=install_requires,
+        python_requires=">=3.7",
     )
 
 if __name__ == "__main__":

--- a/allure-python-commons/setup.py
+++ b/allure-python-commons/setup.py
@@ -56,7 +56,7 @@ def main():
         },
         package_dir={"": "src"},
         install_requires=install_requires,
-        python_requires=">=3.6"
+        python_requires=">=3.7",
     )
 
 

--- a/allure-python-commons/setup.py
+++ b/allure-python-commons/setup.py
@@ -56,7 +56,7 @@ def main():
         },
         package_dir={"": "src"},
         install_requires=install_requires,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 

--- a/allure-python-commons/src/allure_commons/_allure.py
+++ b/allure-python-commons/src/allure_commons/_allure.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import wraps
-from typing import Any, Callable, TypeVar, Union, overload
+from typing import Any, Callable, TypeVar, overload
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -134,7 +136,7 @@ class Dynamic:
         plugin_manager.hook.add_link(url=url, link_type=link_type, name=name)
 
     @staticmethod
-    def parameter(name, value, excluded=None, mode: Union[ParameterMode, None] = None):
+    def parameter(name, value, excluded=None, mode: ParameterMode | None = None):
         plugin_manager.hook.add_parameter(name=name, value=value, excluded=excluded, mode=mode)
 
     @staticmethod
@@ -163,7 +165,7 @@ class Dynamic:
 
 
 @overload
-def step(title: str) -> "StepContext":
+def step(title: str) -> StepContext:
     ...
 
 
@@ -245,7 +247,7 @@ def global_error(value: BaseException) -> None:
 
 
 @overload
-def global_error(value: str, trace: Union[str, None] = None) -> None:
+def global_error(value: str, trace: str | None = None) -> None:
     ...
 
 

--- a/allure-python-commons/src/allure_commons/_allure.py
+++ b/allure-python-commons/src/allure_commons/_allure.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import wraps
-from typing import Any, Callable, TypeVar, Union, overload
+from typing import Any, Callable, TypeVar, overload
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -133,7 +135,7 @@ class Dynamic:
         plugin_manager.hook.add_link(url=url, link_type=link_type, name=name)
 
     @staticmethod
-    def parameter(name, value, excluded=None, mode: Union[ParameterMode, None] = None):
+    def parameter(name, value, excluded=None, mode: ParameterMode | None = None):
         plugin_manager.hook.add_parameter(name=name, value=value, excluded=excluded, mode=mode)
 
     @staticmethod
@@ -162,7 +164,7 @@ class Dynamic:
 
 
 @overload
-def step(title: str) -> "StepContext":
+def step(title: str) -> StepContext:
     ...
 
 

--- a/allure-python-commons/src/allure_commons/logger.py
+++ b/allure-python-commons/src/allure_commons/logger.py
@@ -1,4 +1,3 @@
-import io
 import os
 from pathlib import Path
 import json
@@ -22,7 +21,7 @@ class AllureFileLogger:
         indent = INDENT if os.environ.get("ALLURE_INDENT_OUTPUT") else None
         filename = item.file_pattern.format(prefix=uuid.uuid4())
         data = asdict(item, filter=lambda _, v: v or v is False)
-        with io.open(self._report_dir / filename, "w", encoding="utf8") as json_file:
+        with open(self._report_dir / filename, "w", encoding="utf8") as json_file:
             json.dump(data, json_file, indent=indent, ensure_ascii=False)
 
     @hookimpl

--- a/allure-python-commons/src/allure_commons/utils.py
+++ b/allure-python-commons/src/allure_commons/utils.py
@@ -1,6 +1,5 @@
 import os
 import string
-import sys
 import time
 import uuid
 import json
@@ -41,7 +40,7 @@ def platform_label():
 
 
 def thread_tag():
-    return "{0}-{1}".format(os.getpid(), threading.current_thread().name)
+    return f"{os.getpid()}-{threading.current_thread().name}"
 
 
 def host_tag():
@@ -245,13 +244,7 @@ def func_parameters(func, *args, **kwargs):
         args_dict.pop(arg_spec.args[0], None)
 
     if kwargs:
-        if sys.version_info < (3, 7):
-            # Sort alphabetically as old python versions does
-            # not preserve call order for kwargs.
-            arg_order.extend(sorted(list(kwargs.keys())))
-        else:
-            # Keep py3.7 behaviour to preserve kwargs order
-            arg_order.extend(list(kwargs.keys()))
+        arg_order.extend(list(kwargs.keys()))
         parameters.update(kwargs)
 
     parameters.update(args_dict)
@@ -328,7 +321,7 @@ def get_testplan():
     file_path = os.environ.get("ALLURE_TESTPLAN_PATH")
 
     if file_path and os.path.exists(file_path):
-        with open(file_path, "r") as plan_file:
+        with open(file_path) as plan_file:
             plan = json.load(plan_file)
             planned_tests = plan.get("tests", [])
 

--- a/allure-robotframework/setup.py
+++ b/allure-robotframework/setup.py
@@ -62,5 +62,5 @@ if __name__ == "__main__":
         long_description=get_readme("README.md"),
         long_description_content_type="text/markdown",
         classifiers=classifiers,
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )

--- a/allure-robotframework/setup.py
+++ b/allure-robotframework/setup.py
@@ -62,4 +62,5 @@ if __name__ == "__main__":
         long_description=get_readme("README.md"),
         long_description_content_type="text/markdown",
         classifiers=classifiers,
+        python_requires=">=3.7",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ extend-exclude = [
     "tests/allure_behave/acceptance/behave_support/background/background_steps.py",
 ]
 line-length = 120
+target-version = "py37"
 
 [tool.ruff.lint]
 select = [
@@ -33,5 +34,6 @@ select = [
     "E",  # pycodestyle errors
     "F",  # pyflakes
     "Q",  # flake8-quotes
+    "UP", # pyupgrade
     "W",  # pycodestyle warnings
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ extend-exclude = [
     "tests/allure_behave/acceptance/behave_support/background/background_steps.py",
 ]
 line-length = 120
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 select = [

--- a/tests/allure_pytest/pytest_runner.py
+++ b/tests/allure_pytest/pytest_runner.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from doctest import script_from_examples
 from pathlib import Path
 from pytest import FixtureRequest, Pytester, StashKey
 from tests.e2e import AllureFrameworkRunner, altered_env, PathlikeT
-from typing import Sequence, Tuple, Union
+from typing import Sequence
 
 from allure_commons.logger import AllureMemoryLogger
 
@@ -123,7 +125,7 @@ class AllurePytestRunner(AllureFrameworkRunner):
 
     def run_pytest(
         self,
-        *testfile_literals: Union[str, Tuple[PathlikeT, str]],
+        *testfile_literals: str | tuple[PathlikeT, str],
         conftest_literal: str = None,
         cli_args: Sequence[str] = None,
         testplan: dict = None
@@ -131,7 +133,7 @@ class AllurePytestRunner(AllureFrameworkRunner):
         """Runs a nested pytest session in an isolated allure context.
 
         Arguments:
-            *testfile_literals (str | Tuple[str | Path, str]): test files to
+            *testfile_literals (str | tuple[str | Path, str]): test files to
                 run. Each test file is represented either as a content string or
                 as a tuple of a path and a string. The path should be relative
                 to the pytester's path.

--- a/tests/allure_robotframework/robot_runner.py
+++ b/tests/allure_robotframework/robot_runner.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import robot
 from pytest import FixtureRequest, Pytester
 from tests.e2e import AllureFrameworkRunner, PathlikeT
-from typing import Sequence, Mapping, Union
+from typing import Sequence, Mapping
 from allure_robotframework import allure_robotframework
 
 
@@ -12,7 +14,7 @@ class AllureRobotRunner(AllureFrameworkRunner):
 
     def __init__(self, request: FixtureRequest, pytester: Pytester):
         super().__init__(request, pytester, AllureRobotRunner.LOGGER_PATH)
-        self.rootdir: Union[str, None] = None
+        self.rootdir: str | None = None
 
     def run_robotframework(
         self,

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -3,11 +3,12 @@ with python testing frameworks.
 
 """
 
+from __future__ import annotations
+
 import docutils
 import docutils.nodes
 import docutils.parsers.rst
 import json
-import mock
 import pytest
 import shutil
 import warnings
@@ -18,7 +19,8 @@ from importlib.metadata import version as get_version_metadata
 from packaging.version import parse as parse_version
 from pathlib import Path
 from pytest import FixtureRequest, Pytester, MonkeyPatch
-from typing import Tuple, Mapping, TypeVar, Generator, Callable, Union
+from typing import Mapping, TypeVar, Generator, Callable
+from unittest import mock
 
 import allure_commons
 from allure_commons.logger import AllureMemoryLogger
@@ -56,7 +58,7 @@ def version_gte(package: str, major: int, minor: int = 0, micro: int = 0):
     return not version_lt(package, major, minor, micro)
 
 
-PathlikeT = Union[str, Path]
+PathlikeT = TypeVar("PathlikeT", str, Path)
 
 
 @contextmanager
@@ -167,7 +169,7 @@ def allure_file_context(
 
 def find_node_with_docstring(
     request: FixtureRequest
-) -> Union[Tuple[pytest.Item, str], Tuple[None, None]]:
+) -> tuple[pytest.Item, str] | tuple[None, None]:
     """Find a docstring associated with a test function.
 
     It first checks the function itself and then, if no docstring was found,
@@ -191,7 +193,7 @@ def find_node_with_docstring(
 
 def find_node_with_docstring_or_throw(
     request: FixtureRequest
-) -> Tuple[pytest.Item, str]:
+) -> tuple[pytest.Item, str]:
     """Find a docstring associated with a test function.
 
     It first checks the function itself and then, if no docstring was found,
@@ -468,7 +470,7 @@ class AllureFrameworkRunner:
                 document.
 
         Returns:
-            List[str]: a list of strings, each representing a file content.
+            list[str]: a list of strings, each representing a file content.
 
         """
 
@@ -510,7 +512,7 @@ class AllureFrameworkRunner:
                 extension may be omitted) to its ID in the .rst document.
 
         Returns:
-            List[Path]: a list of the newly created file paths.
+            list[Path]: a list of the newly created file paths.
         """
         return self._copy_files(paths) + self._make_files_from_literals(
             extension,
@@ -526,7 +528,7 @@ class AllureFrameworkRunner:
                 its content (an extension can be omitted).
 
         Returns:
-            List[Path]: a list of the newly created file paths.
+            list[Path]: a list of the newly created file paths.
         """
 
         return [
@@ -544,7 +546,7 @@ class AllureFrameworkRunner:
                 relative to the current test directory.
 
         Returns:
-            List[Path]: a list of the newly created file paths.
+            list[Path]: a list of the newly created file paths.
         """
         dst_paths = []
         for p in src_paths or []:
@@ -567,7 +569,7 @@ class AllureFrameworkRunner:
                 extension may be omitted) to its ID in the .rst document.
 
         Returns:
-            List[Path]: a list of the newly created file paths.
+            list[Path]: a list of the newly created file paths.
         """
 
         return [
@@ -590,7 +592,7 @@ class AllureFrameworkRunner:
         if basepath is None:
             basepath = self.request.path.parent
         path = basepath / path
-        with open(path, mode="r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             return f.read()
 
     def _cache_docstring_test_result(


### PR DESCRIPTION
### Context

- Drops support for Python [3.6](https://docs.python.org/3/whatsnew/3.6.html) and [3.7](https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep557)
  - 3.6 was deprecated in [v2.10.0](https://github.com/allure-framework/allure-python/releases/tag/2.10.0) on 22 Aug 2022 through https://github.com/allure-framework/allure-python/pull/675
  - 3.7 was deprecated in [v2.14.0](https://github.com/allure-framework/allure-python/releases/tag/2.14.0) on 3 Apr 2025 through https://github.com/allure-framework/allure-python/pull/842
- Declare required Python versions in all packages to avoid relying on the _commons_ transient dependency
  - Supports package managers and linters (such as `ruff` - see [Inferring the Python version](https://docs.astral.sh/ruff/configuration/#inferring-the-python-version))
- Applies and enforces Python 3.8+ syntax upgrades (`ruff check --target-version="py38" --select=UP --fix`) - following merge of #888
  - [UP006](https://docs.astral.sh/ruff/rules/non-pep585-annotation/) - Use `tuple` instead of `Tuple` for type annotation
  - [UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/) - Use `X | Y` for type annotations.
  - [UP008](https://docs.astral.sh/ruff/rules/super-call-with-parameters/) - Use `super()` instead of `super(__class__, self)`
  - [UP015](https://docs.astral.sh/ruff/rules/redundant-open-modes/) - Unnecessary mode argument
  - [UP020](https://docs.astral.sh/ruff/rules/open-alias/) - Use builtin `open`
  - [UP026](https://docs.astral.sh/ruff/rules/deprecated-mock-import/) - `mock` is deprecated, use `unittest.mock`
  - [UP030](https://docs.astral.sh/ruff/rules/format-literals/) - Use implicit references for positional format fields
  - [UP032](https://docs.astral.sh/ruff/rules/f-string/) - Use f-string instead of `format` call

Enables usage of [PEP 563](https://peps.python.org/pep-0563/) postponed evaluation of annotations (`from __future__ import annotations`) towards #878 - which would otherwise break if applied, for users who attempt to install and run the latest releases using Python 3.6.

Upgrading enables removal of [`attrs`](https://www.attrs.org/en/stable/index.html) dependency through migration to the 3.7+ native `dataclasses` ([PEP 557](https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep557)) without installing [backports](https://pypi.org/project/dataclasses/) and which provides improved type hinting and associated IDE support towards #878 - provided there are no constraints on retaining `attrs`.