### PR TITLE
feat(commons): data model type annotations

### DIFF
--- a/allure-python-commons/src/allure_commons/lifecycle.py
+++ b/allure-python-commons/src/allure_commons/lifecycle.py
@@ -36,8 +36,7 @@ class AllureLifecycle:
 
     @contextmanager
     def schedule_test_case(self, uuid=None):
-        test_result = TestResult()
-        test_result.uuid = uuid or uuid4()
+        test_result = TestResult(uuid=uuid or uuid4())
         self._items[test_result.uuid] = test_result
         yield test_result
 

--- a/allure-python-commons/src/allure_commons/lifecycle.py
+++ b/allure-python-commons/src/allure_commons/lifecycle.py
@@ -35,8 +35,7 @@ class AllureLifecycle:
 
     @contextmanager
     def schedule_test_case(self, uuid=None):
-        test_result = TestResult()
-        test_result.uuid = uuid or uuid4()
+        test_result = TestResult(uuid=uuid or uuid4())
         self._items[test_result.uuid] = test_result
         yield test_result
 

--- a/allure-python-commons/src/allure_commons/model2.py
+++ b/allure-python-commons/src/allure_commons/model2.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from attr import attrs, attrib
 from attr import Factory
-
 
 TEST_GROUP_PATTERN = "{prefix}-container.json"
 TEST_CASE_PATTERN = "{prefix}-result.json"
@@ -12,49 +13,49 @@ INDENT = 4
 class TestResultContainer:
     file_pattern = TEST_GROUP_PATTERN
 
-    uuid = attrib(default=None)
-    name = attrib(default=None)
-    children = attrib(default=Factory(list))
-    description = attrib(default=None)
-    descriptionHtml = attrib(default=None)
-    befores = attrib(default=Factory(list))
-    afters = attrib(default=Factory(list))
-    links = attrib(default=Factory(list))
-    start = attrib(default=None)
-    stop = attrib(default=None)
+    uuid: str = attrib(default=None)
+    name: str | None = attrib(default=None)
+    children: list[str] = attrib(default=Factory(list))
+    description: str | None = attrib(default=None)
+    descriptionHtml: str | None = attrib(default=None)
+    befores: list[TestBeforeResult] = attrib(default=Factory(list))
+    afters: list[TestAfterResult] = attrib(default=Factory(list))
+    links: list[Link] = attrib(default=Factory(list))
+    start: int | None = attrib(default=None)
+    stop: int | None = attrib(default=None)
 
 
 @attrs
 class ExecutableItem:
-    name = attrib(default=None)
-    status = attrib(default=None)
-    statusDetails = attrib(default=None)
-    stage = attrib(default=None)
-    description = attrib(default=None)
-    descriptionHtml = attrib(default=None)
-    steps = attrib(default=Factory(list))
-    attachments = attrib(default=Factory(list))
-    parameters = attrib(default=Factory(list))
-    start = attrib(default=None)
-    stop = attrib(default=None)
+    name: str | None = attrib(default=None)
+    status: str | None = attrib(default=None)
+    statusDetails: StatusDetails | None = attrib(default=None)
+    stage: str | None = attrib(default=None)
+    description: str | None = attrib(default=None)
+    descriptionHtml: str | None = attrib(default=None)
+    steps: list[TestStepResult] = attrib(default=Factory(list))
+    attachments: list[Attachment] = attrib(default=Factory(list))
+    parameters: list[Parameter] = attrib(default=Factory(list))
+    start: int | None = attrib(default=None)
+    stop: int | None = attrib(default=None)
 
 
 @attrs
 class TestResult(ExecutableItem):
     file_pattern = TEST_CASE_PATTERN
 
-    uuid = attrib(default=None)
-    historyId = attrib(default=None)
-    testCaseId = attrib(default=None)
-    fullName = attrib(default=None)
-    labels = attrib(default=Factory(list))
-    links = attrib(default=Factory(list))
-    titlePath = attrib(default=Factory(list))
+    uuid: str = attrib(default=None)
+    historyId: str | None = attrib(default=None)
+    testCaseId: str | None = attrib(default=None)
+    fullName: str | None = attrib(default=None)
+    labels: list[Label] = attrib(default=Factory(list))
+    links: list[Link] = attrib(default=Factory(list))
+    titlePath: list[str] = attrib(default=Factory(list))
 
 
 @attrs
 class TestStepResult(ExecutableItem):
-    id = attrib(default=None)
+    id: str | None = attrib(default=None)
 
 
 @attrs
@@ -69,37 +70,37 @@ class TestAfterResult(ExecutableItem):
 
 @attrs
 class Parameter:
-    name = attrib(default=None)
-    value = attrib(default=None)
-    excluded = attrib(default=None)
-    mode = attrib(default=None)
+    name: str = attrib(default=None)
+    value: str = attrib(default=None)
+    excluded: bool | None = attrib(default=None)
+    mode: str | None = attrib(default=None)
 
 
 @attrs
 class Label:
-    name = attrib(default=None)
-    value = attrib(default=None)
+    name: str = attrib(default=None)
+    value: str = attrib(default=None)
 
 
 @attrs
 class Link:
-    type = attrib(default=None)
-    url = attrib(default=None)
-    name = attrib(default=None)
+    type: str | None = attrib(default=None)
+    url: str = attrib(default=None)
+    name: str | None = attrib(default=None)
 
 
 @attrs
 class StatusDetails:
-    known = attrib(default=None)
-    flaky = attrib(default=None)
-    message = attrib(default=None)
-    trace = attrib(default=None)
+    known: bool | None = attrib(default=None)
+    flaky: bool | None = attrib(default=None)
+    message: str | None = attrib(default=None)
+    trace: str | None = attrib(default=None)
 
 @attrs
 class Attachment:
-    name = attrib(default=None)
-    source = attrib(default=None)
-    type = attrib(default=None)
+    name: str = attrib(default=None)
+    source: str = attrib(default=None)
+    type: str | None = attrib(default=None)
 
 
 class Status:

--- a/allure-python-commons/src/allure_commons/model2.py
+++ b/allure-python-commons/src/allure_commons/model2.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from attr import attrs, attrib
 from attr import Factory
-
 
 TEST_GROUP_PATTERN = "{prefix}-container.json"
 TEST_CASE_PATTERN = "{prefix}-result.json"
@@ -13,49 +14,49 @@ INDENT = 4
 class TestResultContainer:
     file_pattern = TEST_GROUP_PATTERN
 
-    uuid = attrib(default=None)
-    name = attrib(default=None)
-    children = attrib(default=Factory(list))
-    description = attrib(default=None)
-    descriptionHtml = attrib(default=None)
-    befores = attrib(default=Factory(list))
-    afters = attrib(default=Factory(list))
-    links = attrib(default=Factory(list))
-    start = attrib(default=None)
-    stop = attrib(default=None)
+    uuid: str = attrib(default=None)
+    name: str | None = attrib(default=None)
+    children: list[str] = attrib(default=Factory(list))
+    description: str | None = attrib(default=None)
+    descriptionHtml: str | None = attrib(default=None)
+    befores: list[TestBeforeResult] = attrib(default=Factory(list))
+    afters: list[TestAfterResult] = attrib(default=Factory(list))
+    links: list[Link] = attrib(default=Factory(list))
+    start: int | None = attrib(default=None)
+    stop: int | None = attrib(default=None)
 
 
 @attrs
 class ExecutableItem:
-    name = attrib(default=None)
-    status = attrib(default=None)
-    statusDetails = attrib(default=None)
-    stage = attrib(default=None)
-    description = attrib(default=None)
-    descriptionHtml = attrib(default=None)
-    steps = attrib(default=Factory(list))
-    attachments = attrib(default=Factory(list))
-    parameters = attrib(default=Factory(list))
-    start = attrib(default=None)
-    stop = attrib(default=None)
+    name: str | None = attrib(default=None)
+    status: str | None = attrib(default=None)
+    statusDetails: StatusDetails | None = attrib(default=None)
+    stage: str | None = attrib(default=None)
+    description: str | None = attrib(default=None)
+    descriptionHtml: str | None = attrib(default=None)
+    steps: list[TestStepResult] = attrib(default=Factory(list))
+    attachments: list[Attachment] = attrib(default=Factory(list))
+    parameters: list[Parameter] = attrib(default=Factory(list))
+    start: int | None = attrib(default=None)
+    stop: int | None = attrib(default=None)
 
 
 @attrs
 class TestResult(ExecutableItem):
     file_pattern = TEST_CASE_PATTERN
 
-    uuid = attrib(default=None)
-    historyId = attrib(default=None)
-    testCaseId = attrib(default=None)
-    fullName = attrib(default=None)
-    labels = attrib(default=Factory(list))
-    links = attrib(default=Factory(list))
-    titlePath = attrib(default=Factory(list))
+    uuid: str = attrib(default=None)
+    historyId: str | None = attrib(default=None)
+    testCaseId: str | None = attrib(default=None)
+    fullName: str | None = attrib(default=None)
+    labels: list[Label] = attrib(default=Factory(list))
+    links: list[Link] = attrib(default=Factory(list))
+    titlePath: list[str] = attrib(default=Factory(list))
 
 
 @attrs
 class TestStepResult(ExecutableItem):
-    id = attrib(default=None)
+    id: str | None = attrib(default=None)
 
 
 @attrs
@@ -70,56 +71,56 @@ class TestAfterResult(ExecutableItem):
 
 @attrs
 class Parameter:
-    name = attrib(default=None)
-    value = attrib(default=None)
-    excluded = attrib(default=None)
-    mode = attrib(default=None)
+    name: str = attrib(default=None)
+    value: str = attrib(default=None)
+    excluded: bool | None = attrib(default=None)
+    mode: str | None = attrib(default=None)
 
 
 @attrs
 class Label:
-    name = attrib(default=None)
-    value = attrib(default=None)
+    name: str = attrib(default=None)
+    value: str = attrib(default=None)
 
 
 @attrs
 class Link:
-    type = attrib(default=None)
-    url = attrib(default=None)
-    name = attrib(default=None)
+    type: str | None = attrib(default=None)
+    url: str = attrib(default=None)
+    name: str | None = attrib(default=None)
 
 
 @attrs
 class StatusDetails:
-    known = attrib(default=None)
-    flaky = attrib(default=None)
-    message = attrib(default=None)
-    trace = attrib(default=None)
+    known: bool | None = attrib(default=None)
+    flaky: bool | None = attrib(default=None)
+    message: str | None = attrib(default=None)
+    trace: str | None = attrib(default=None)
 
 
 @attrs
 class Attachment:
-    name = attrib(default=None)
-    source = attrib(default=None)
-    type = attrib(default=None)
+    name: str = attrib(default=None)
+    source: str = attrib(default=None)
+    type: str | None = attrib(default=None)
 
 
 @attrs
 class GlobalAttachment(Attachment):
-    timestamp = attrib(default=None)
+    timestamp: int = attrib(default=None)
 
 
 @attrs
 class GlobalError(StatusDetails):
-    timestamp = attrib(default=None)
+    timestamp: int = attrib(default=None)
 
 
 @attrs
 class Globals:
     file_pattern = GLOBALS_PATTERN
 
-    attachments = attrib(default=Factory(list))
-    errors = attrib(default=Factory(list))
+    attachments: list[GlobalAttachment] = attrib(default=Factory(list))
+    errors: list[GlobalError] = attrib(default=Factory(list))
 
 
 class Status:

--- a/allure-python-commons/src/allure_commons/types.py
+++ b/allure-python-commons/src/allure_commons/types.py
@@ -1,7 +1,5 @@
 from enum import Enum
 
-ALLURE_UNIQUE_LABELS = ["severity", "thread", "host"]
-
 
 class Severity(str, Enum):
     BLOCKER = "blocker"
@@ -34,9 +32,11 @@ class LabelType(str):
     MANUAL = "ALLURE_MANUAL"
 
 
-class AttachmentType(Enum):
+ALLURE_UNIQUE_LABELS = [LabelType.SEVERITY, LabelType.THREAD, LabelType.HOST]
 
-    def __init__(self, mime_type, extension):
+
+class AttachmentType(Enum):
+    def __init__(self, mime_type: str, extension: str) -> None:
         self.mime_type = mime_type
         self.extension = extension
 
@@ -66,7 +66,7 @@ class AttachmentType(Enum):
     PDF = ("application/pdf", "pdf")
 
 
-class ParameterMode(Enum):
+class ParameterMode(str, Enum):
     HIDDEN = "hidden"
     MASKED = "masked"
-    DEFAULT = None
+    DEFAULT = "default"


### PR DESCRIPTION
### Context

Establish type annotations on common data models towards #878 - to enable static type checking and rich language services through language servers. The [`ty` Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=astral-sh.ty) will only recognise `attrs` attributes once type annotations are provided for instance - see [`attrs` documentation on type annotations](https://www.attrs.org/en/stable/types.html).

### Changes

-  Updated `ParameterMode.DEFAULT` to a `"default"` string from `None` - matching [allure2](https://github.com/allure-framework/allure3/blob/204c4c7ab95f901b73b237e489b5d7b8e6c15539/packages/reader/src/allure2/model.ts#L24-L28)
    - Enabled updating `ParameterMode` to a string-based enum of `(str, Enum)` rather than `Enum`
- Initialised `TestResult` with a UUID - rather than initialise without it and then set its attribute
- Updated `ALLURE_UNIQUE_LABELS` to the same values, though via `LabelType` attributes to avoid duplication

Withholding removing `None` from required fields - being a breaking change for any improper initialisation - reserving for more fundamental model updates. Similarly withholding standardising all types to string-based enums.

#### Screenshots

| Without annotations | With annotations |
| ---- | ---- |
|  <img width="347" height="53" alt="image" src="https://github.com/user-attachments/assets/7572c381-9c92-40c8-bb44-9942574e5ecc" /> | <img width="600" height="174" alt="image" src="https://github.com/user-attachments/assets/a534eb53-5f3b-4b26-a22e-d9396cecfdad" /> |
| <img width="782" height="167" alt="missing_types" src="https://github.com/user-attachments/assets/6613bac0-4163-4123-836e-a6f8db3a5e37" /> |  <img width="609" height="150" alt="present_types" src="https://github.com/user-attachments/assets/885d2ddd-8226-440b-a15a-d11a50e6b48a" /> |
| | <img width="864" height="54" alt="image" src="https://github.com/user-attachments/assets/a2df2030-dd5e-4026-bd4c-bafc5f2fdff2" /> |
| | <img width="744" height="140" alt="image" src="https://github.com/user-attachments/assets/3ffb3d34-e428-42f8-a9ef-90e11f4a41e4" /> |