### PR TITLE
chore(ci): test pytest v9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,13 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        pytest-version: ["7.*", "8.*"]
+        pytest-version: ["7.*", "8.*", "9.*"]
+        exclude:
+          # pytest 9 supports Python >= 3.10
+          - python-version: "3.8"
+            pytest-version: "9.*"
+          - python-version: "3.9"
+            pytest-version: "9.*"
     env:
       TEST_TMP: /tmp
       ALLURE_INDENT_OUTPUT: yep


### PR DESCRIPTION
### Context

Test pytest [v9](https://github.com/pytest-dev/pytest/releases/tag/9.0.0) - released 8 November 2025 - in pipeline to ensure compatibility with the latest releases.