### PR TITLE
chore(ci): install dependencies through `uv`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,12 +80,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
+          activate-environment: "true"
           python-version: "3.13"
 
       - name: Install linting packages
-        run: pip install -r ./requirements/linting.txt
+        run: uv pip install -r ./requirements/linting.txt
 
       - name: Linting the codebase
         run: poe linter --output-format=github
@@ -112,13 +113,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
+          activate-environment: "true"
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages
         run: |
-          pip install ./allure-python-commons \
+          uv pip install ./allure-python-commons \
             ./allure-python-commons-test \
             ./allure-pytest \
             pytest==${{ matrix.pytest-version }} \
@@ -147,13 +149,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
+          activate-environment: "true"
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages
         run: |
-          pip install ./allure-python-commons \
+          uv pip install ./allure-python-commons \
             ./allure-python-commons-test \
             ./${{ matrix.package }} \
             -r ./requirements/testing.txt \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,12 +80,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
+          activate-environment: "true"
           python-version: "3.13"
 
       - name: Install linting packages
-        run: pip install -r ./requirements/linting.txt
+        run: uv pip install -r ./requirements/linting.txt
 
       - name: Linting the codebase
         run: poe linter --output-format=github
@@ -106,13 +107,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
+          activate-environment: "true"
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages
         run: |
-          pip install ./allure-python-commons \
+          uv pip install ./allure-python-commons \
             ./allure-python-commons-test \
             ./allure-pytest \
             pytest==${{ matrix.pytest-version }} \
@@ -141,13 +143,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v7
         with:
+          activate-environment: "true"
           python-version: ${{ matrix.python-version }}
 
       - name: Install packages
         run: |
-          pip install ./allure-python-commons \
+          uv pip install ./allure-python-commons \
             ./allure-python-commons-test \
             ./${{ matrix.package }} \
             -r ./requirements/testing.txt \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,14 +16,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: astral-sh/setup-uv@v7
       with:
+        activate-environment: "true"
         python-version: '3.x'
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+      run: uv pip install setuptools wheel twine
 
     - name: Build and publish
       env:


### PR DESCRIPTION
### Context

Install dependencies in pipeline via [uv](https://docs.astral.sh/uv/).

This halves CI run time e.g. `20m 47s` ([#20572551437](https://github.com/allure-framework/allure-python/actions/runs/20572551437/usage)) -> `12m 44s` ([#20647876970](https://github.com/allure-framework/allure-python/actions/runs/20647876970/usage)).