### PR TITLE
fix(allure-pytest): runtime overrides of parameter options

### DIFF
--- a/allure-pytest-bdd/src/allure_api_listener.py
+++ b/allure-pytest-bdd/src/allure_api_listener.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 import allure_commons
@@ -5,6 +9,7 @@ import allure_commons
 from allure_commons.model2 import Label
 from allure_commons.model2 import Link
 from allure_commons.model2 import Parameter
+from allure_commons.types import ParameterMode
 from allure_commons.utils import represent
 
 from .utils import ALLURE_DESCRIPTION_HTML_MARK
@@ -85,7 +90,13 @@ class AllurePytestBddApiHooks:
             test_result.links.append(Link(url=url, name=name, type=link_type))
 
     @allure_commons.hookimpl
-    def add_parameter(self, name, value, excluded, mode):
+    def add_parameter(
+        self,
+        name: str,
+        value: Any,
+        excluded: bool | None,
+        mode: ParameterMode | None,
+    ) -> None:
         with self.lifecycle.update_test_case() as test_result:
             test_result.parameters.append(
                 Parameter(

--- a/allure-pytest-bdd/src/allure_api_listener.py
+++ b/allure-pytest-bdd/src/allure_api_listener.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 import allure_commons
@@ -5,6 +9,7 @@ import allure_commons
 from allure_commons.model2 import Label
 from allure_commons.model2 import Link
 from allure_commons.model2 import Parameter
+from allure_commons.types import ParameterMode
 from allure_commons.utils import represent
 
 from .utils import ALLURE_DESCRIPTION_HTML_MARK
@@ -88,7 +93,13 @@ class AllurePytestBddApiHooks:
             test_result.links.append(Link(url=url, name=name, type=link_type))
 
     @allure_commons.hookimpl
-    def add_parameter(self, name, value, excluded, mode):
+    def add_parameter(
+        self,
+        name: str,
+        value: Any,
+        excluded: bool | None,
+        mode: ParameterMode | None,
+    ) -> None:
         with self.lifecycle.update_test_case() as test_result:
             test_result.parameters.append(
                 Parameter(

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 import doctest
 
@@ -293,17 +297,26 @@ class AllureListener:
             test_result.labels.append(Label(label_type, label))
 
     @allure_commons.hookimpl
-    def add_parameter(self, name, value, excluded, mode: ParameterMode):
+    def add_parameter(
+        self,
+        name: str,
+        value: Any,
+        excluded: bool | None,
+        mode: ParameterMode | None,
+    ) -> None:
         test_result: TestResult = self.allure_logger.get_test(None)
-        existing_param = next(filter(lambda x: x.name == name, test_result.parameters), None)
+        existing_param = next((p for p in test_result.parameters if p.name == name), None)
+
         if existing_param:
             existing_param.value = represent(value)
+            existing_param.excluded = excluded
+            existing_param.mode = mode.value if mode else None
         else:
             test_result.parameters.append(
                 Parameter(
                     name=name,
                     value=represent(value),
-                    excluded=excluded or None,
+                    excluded=excluded,
                     mode=mode.value if mode else None
                 )
             )

--- a/allure-pytest/src/listener.py
+++ b/allure-pytest/src/listener.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 import doctest
 
@@ -317,17 +321,26 @@ class AllureListener:
             test_result.labels.append(Label(label_type, label))
 
     @allure_commons.hookimpl
-    def add_parameter(self, name, value, excluded, mode: ParameterMode):
+    def add_parameter(
+        self,
+        name: str,
+        value: Any,
+        excluded: bool | None,
+        mode: ParameterMode | None,
+    ) -> None:
         test_result: TestResult = self.allure_logger.get_test(None)
-        existing_param = next(filter(lambda x: x.name == name, test_result.parameters), None)
+        existing_param = next((p for p in test_result.parameters if p.name == name), None)
+
         if existing_param:
             existing_param.value = represent(value)
+            existing_param.excluded = excluded
+            existing_param.mode = mode.value if mode else None
         else:
             test_result.parameters.append(
                 Parameter(
                     name=name,
                     value=represent(value),
-                    excluded=excluded or None,
+                    excluded=excluded,
                     mode=mode.value if mode else None
                 )
             )

--- a/allure-python-commons-test/src/result.py
+++ b/allure-python-commons-test/src/result.py
@@ -254,8 +254,8 @@ def with_trace_contains(string):
 def with_no_trace():
     return not_(has_entry("trace", anything()))
 
-def with_excluded():
-    return has_entry("excluded", True)
+def with_excluded(excluded: bool = True):
+    return has_entry("excluded", excluded)
 
 
 def with_mode(mode):

--- a/allure-python-commons-test/src/result.py
+++ b/allure-python-commons-test/src/result.py
@@ -221,8 +221,8 @@ def with_trace_contains(string):
     return has_entry("trace", contains_string(string))
 
 
-def with_excluded():
-    return has_entry("excluded", True)
+def with_excluded(excluded: bool = True):
+    return has_entry("excluded", excluded)
 
 
 def with_mode(mode):

--- a/allure-python-commons/src/allure_commons/_allure.py
+++ b/allure-python-commons/src/allure_commons/_allure.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import wraps
-from typing import Any, Callable, TypeVar, Union, overload
+from typing import Any, Callable, TypeVar, overload
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -134,7 +136,12 @@ class Dynamic:
         plugin_manager.hook.add_link(url=url, link_type=link_type, name=name)
 
     @staticmethod
-    def parameter(name, value, excluded=None, mode: Union[ParameterMode, None] = None):
+    def parameter(
+        name: str,
+        value: Any,
+        excluded: bool | None = None,
+        mode: ParameterMode | None = None,
+    ) -> None:
         plugin_manager.hook.add_parameter(name=name, value=value, excluded=excluded, mode=mode)
 
     @staticmethod
@@ -245,7 +252,7 @@ def global_error(value: BaseException) -> None:
 
 
 @overload
-def global_error(value: str, trace: Union[str, None] = None) -> None:
+def global_error(value: str, trace: str | None = None) -> None:
     ...
 
 

--- a/allure-python-commons/src/allure_commons/_allure.py
+++ b/allure-python-commons/src/allure_commons/_allure.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import wraps
-from typing import Any, Callable, TypeVar, Union, overload
+from typing import Any, Callable, TypeVar, overload
 
 from allure_commons._core import plugin_manager
 from allure_commons.types import LabelType, LinkType, ParameterMode
@@ -133,7 +135,12 @@ class Dynamic:
         plugin_manager.hook.add_link(url=url, link_type=link_type, name=name)
 
     @staticmethod
-    def parameter(name, value, excluded=None, mode: Union[ParameterMode, None] = None):
+    def parameter(
+        name: str,
+        value: Any,
+        excluded: bool | None = None,
+        mode: ParameterMode | None = None,
+    ) -> None:
         plugin_manager.hook.add_parameter(name=name, value=value, excluded=excluded, mode=mode)
 
     @staticmethod

--- a/allure-python-commons/src/allure_commons/_hooks.py
+++ b/allure-python-commons/src/allure_commons/_hooks.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
 from pluggy import HookspecMarker, HookimplMarker
+
+from allure_commons.types import ParameterMode
 
 hookspec = HookspecMarker("allure")
 hookimpl = HookimplMarker("allure")
@@ -47,7 +53,13 @@ class AllureUserHooks:
         """ url """
 
     @hookspec
-    def add_parameter(self, name, value, excluded, mode):
+    def add_parameter(
+        self,
+        name: str,
+        value: Any,
+        excluded: bool | None,
+        mode: ParameterMode | None,
+    ) -> None:
         """ parameter """
 
     @hookspec

--- a/tests/allure_pytest/acceptance/parametrization/parametrization_test.py
+++ b/tests/allure_pytest/acceptance/parametrization/parametrization_test.py
@@ -1,3 +1,4 @@
+import pytest
 from hamcrest import assert_that, has_entry, ends_with, all_of
 from tests.allure_pytest.pytest_runner import AllurePytestRunner
 
@@ -181,6 +182,30 @@ def test_dynamic_parameter_excluded(allure_pytest_runner: AllurePytestRunner):
     )
 
 
+@pytest.mark.xfail(reason="Known issue: cannot explicitly set excluded flag to False")
+def test_dynamic_parameter_excluded_false(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import allure
+
+    >>> def test_parameter_excluded():
+    ...     allure.dynamic.parameter("param1", "param-value", excluded=False)
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_parameter_excluded",
+            has_parameter(
+                "param1",
+                "'param-value'",
+                with_excluded(False)
+            )
+        )
+    )
+
+
 def test_dynamic_parameter_mode(allure_pytest_runner: AllurePytestRunner):
     """
     >>> import allure
@@ -221,6 +246,58 @@ def test_dynamic_parameter_override(allure_pytest_runner: AllurePytestRunner):
         has_test_case(
             "test_parameter_override[param-id]",
             has_parameter("param1", "'readable-value'")
+        )
+    )
+
+
+@pytest.mark.xfail(reason="Known issue: cannot override excluded flag")
+def test_dynamic_parameter_override_excluded(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import pytest
+    ... import allure
+
+    >>> @pytest.mark.parametrize("param1", [object()], ids=["param-id"])
+    ... def test_parameter_override(param1):
+    ...     allure.dynamic.parameter("param1", "readable-value", excluded=True)
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_parameter_override[param-id]",
+            has_parameter(
+                "param1",
+                "'readable-value'",
+                with_excluded(),
+            ),
+        )
+    )
+
+
+@pytest.mark.xfail(reason="Known issue: cannot override mode")
+def test_dynamic_parameter_override_mode(allure_pytest_runner: AllurePytestRunner):
+    """
+    >>> import pytest
+    ... import allure
+
+    >>> @pytest.mark.parametrize("param1", [object()], ids=["param-id"])
+    ... def test_parameter_override(param1):
+    ...     allure.dynamic.parameter("param1", "readable-value", mode=allure.parameter_mode.MASKED)
+    """
+
+    allure_results = allure_pytest_runner.run_docstring()
+
+    assert_that(
+        allure_results,
+        has_test_case(
+            "test_parameter_override[param-id]",
+            has_parameter(
+                "param1",
+                "'readable-value'",
+                with_mode("masked"),
+            ),
         )
     )
 

--- a/tests/allure_pytest/acceptance/parametrization/parametrization_test.py
+++ b/tests/allure_pytest/acceptance/parametrization/parametrization_test.py
@@ -1,4 +1,3 @@
-import pytest
 from hamcrest import assert_that, has_entry, ends_with, all_of
 from tests.allure_pytest.pytest_runner import AllurePytestRunner
 
@@ -182,7 +181,6 @@ def test_dynamic_parameter_excluded(allure_pytest_runner: AllurePytestRunner):
     )
 
 
-@pytest.mark.xfail(reason="Known issue: cannot explicitly set excluded flag to False")
 def test_dynamic_parameter_excluded_false(allure_pytest_runner: AllurePytestRunner):
     """
     >>> import allure
@@ -250,7 +248,6 @@ def test_dynamic_parameter_override(allure_pytest_runner: AllurePytestRunner):
     )
 
 
-@pytest.mark.xfail(reason="Known issue: cannot override excluded flag")
 def test_dynamic_parameter_override_excluded(allure_pytest_runner: AllurePytestRunner):
     """
     >>> import pytest
@@ -276,7 +273,6 @@ def test_dynamic_parameter_override_excluded(allure_pytest_runner: AllurePytestR
     )
 
 
-@pytest.mark.xfail(reason="Known issue: cannot override mode")
 def test_dynamic_parameter_override_mode(allure_pytest_runner: AllurePytestRunner):
     """
     >>> import pytest


### PR DESCRIPTION
### Context

- Fixes #822 to enable setting the `excluded` flag and `mode` of parameters at runtime - matching [documented intended usage](https://github.com/allure-framework/allure-python/blob/203172469834d894f2ecb91234217b8f8b4c5abd/allure-pytest/examples/parameter/dynamic_parameter.rst#dynamic-parameter)
- Fix that `excluded` flag cannot explicitly be set to `False` - see [expected sample output in allure2](https://github.com/allure-framework/allure2/blob/56d80a0beec29f8b15f42af8badcc932d12d9e7b/allure-generator/src/test/resources/allure2/parameters.json#L14) based on use of `or` operator that evaluates to `None` on assignment
- Enhance Allure API `parameter` type hints to cover full method signature