### PR TITLE
feat(commons): markdown attachment type

### DIFF
--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -1,17 +1,17 @@
 import os
 import sys
+from importlib.metadata import PackageNotFoundError, distribution
 from setuptools import setup
-from pkg_resources import require, DistributionNotFound, VersionConflict
 
 try:
-    require("pytest-allure-adaptor")
+    distribution("pytest-allure-adaptor")
     print("""
     You have pytest-allure-adaptor installed.
     You need to remove pytest-allure-adaptor from your site-packages
     before installing allure-pytest, or conflicts may result.
     """)
     sys.exit()
-except (DistributionNotFound, VersionConflict):
+except PackageNotFoundError:
     pass
 
 PACKAGE = "allure-pytest"
@@ -33,19 +33,16 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
-setup_requires = [
-    "setuptools_scm"
-]
+setup_requires = ["setuptools_scm"]
 
 
-install_requires = [
-    "pytest>=4.5.0"
-]
+install_requires = ["pytest>=4.5.0"]
 
 
 def prepare_version():
     from setuptools_scm import get_version
-    configuration = {"root": "..",  "relative_to": __file__}
+
+    configuration = {"root": "..", "relative_to": __file__}
     version = get_version(**configuration)
     install_requires.append(f"allure-python-commons=={version}")
     return configuration
@@ -76,8 +73,9 @@ def main():
         package_dir={"allure_pytest": "src"},
         entry_points={"pytest11": ["allure_pytest = allure_pytest.plugin"]},
         setup_requires=setup_requires,
-        install_requires=install_requires
+        install_requires=install_requires,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/allure-python-commons/src/allure_commons/types.py
+++ b/allure-python-commons/src/allure_commons/types.py
@@ -46,6 +46,7 @@ class AttachmentType(Enum):
     URI_LIST = ("text/uri-list", "uri")
 
     HTML = ("text/html", "html")
+    MARKDOWN = ("text/markdown", "md")
     XML = ("application/xml", "xml")
     JSON = ("application/json", "json")
     YAML = ("application/yaml", "yaml")


### PR DESCRIPTION
### Context

Provides an attachment type for markdown files.

```python
import allure

def test_function():
    allure.attach.file(
        source="file.md",
        attachment_type=allure.attachment_type.MARKDOWN,
    )
```

#### Checklist

- [x] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2