### PR TITLE
Fix ModuleNotFoundError when creating distributions with setup.py

### DIFF
--- a/allure-behave/setup.py
+++ b/allure-behave/setup.py
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 setup_requires = [
-    "setuptools_scm"
+    "setuptools_scm<10"
 ]
 
 install_requires = [

--- a/allure-nose2/setup.py
+++ b/allure-nose2/setup.py
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 setup_requires = [
-    "setuptools_scm"
+    "setuptools_scm<10"
 ]
 
 install_requires = [

--- a/allure-pytest-bdd/setup.py
+++ b/allure-pytest-bdd/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 setup_requires = [
-    "setuptools_scm"
+    "setuptools_scm<10"
 ]
 
 install_requires = [

--- a/allure-pytest/setup.py
+++ b/allure-pytest/setup.py
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 setup_requires = [
-    "setuptools_scm"
+    "setuptools_scm<10"
 ]
 
 

--- a/allure-python-commons-test/setup.py
+++ b/allure-python-commons-test/setup.py
@@ -32,7 +32,7 @@ def main():
     setup(
         name=PACKAGE,
         use_scm_version={"root": "..", "relative_to": __file__},
-        setup_requires=["setuptools_scm"],
+        setup_requires=["setuptools_scm<10"],
         description=(
             "A collection of PyHamcrest matchers to test Allure adapters for "
             "Python test frameworks"

--- a/allure-python-commons/setup.py
+++ b/allure-python-commons/setup.py
@@ -33,7 +33,7 @@ def main():
     setup(
         name=PACKAGE,
         use_scm_version={"root": "..", "relative_to": __file__},
-        setup_requires=["setuptools_scm"],
+        setup_requires=["setuptools_scm<10"],
         description=(
             "Contains the API for end users as well as helper functions and "
             "classes to build Allure adapters for Python test frameworks"

--- a/allure-robotframework/setup.py
+++ b/allure-robotframework/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 setup_requires = [
-    "setuptools_scm"
+    "setuptools_scm<10"
 ]
 
 install_requires = [


### PR DESCRIPTION
### Context

The PR introduces a version restriction on `setuptools_scm` used in `setup.py` scripts. The restriction prevents `ModuleNotFoundError` ([see here](https://github.com/allure-framework/allure-python/actions/runs/24887446788/job/72870869070)) until we move to a PEP-517 compliant installer.
