### PR TITLE
fix(commons): allow md5 hashing on FIPS-compliant hosts

### DIFF
--- a/allure-python-commons/src/allure_commons/utils.py
+++ b/allure-python-commons/src/allure_commons/utils.py
@@ -16,7 +16,11 @@ from traceback import format_exception_only
 
 
 def md5(*args):
-    m = hashlib.md5(usedforsecurity=False)
+    # usedforsecurity argument is only available in 3.9+
+    if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+        m = hashlib.md5(usedforsecurity=False)
+    else:
+        m = hashlib.md5()
     for arg in args:
         if not isinstance(arg, bytes):
             if not isinstance(arg, str):

--- a/allure-python-commons/src/allure_commons/utils.py
+++ b/allure-python-commons/src/allure_commons/utils.py
@@ -16,7 +16,7 @@ from traceback import format_exception_only
 
 
 def md5(*args):
-    m = hashlib.md5()
+    m = hashlib.md5(usedforsecurity=False)
     for arg in args:
         if not isinstance(arg, bytes):
             if not isinstance(arg, str):

--- a/tests/allure_pytest/acceptance/fixture/fixture_test.py
+++ b/tests/allure_pytest/acceptance/fixture/fixture_test.py
@@ -10,6 +10,15 @@ from allure_commons_test.result import has_step
 
 fixture_scopes = ["session", "module", "class", "function"]
 
+# This is a workaround so test_fixture_override and test_dynamically_called_fixture work with all versions of pytest.
+# In pytest 9.1.0 (specifically PR #14275), the behavior of these tests changed: an additional finalizer was added
+# that always appears first in the list of finalizers. Because allure-pytest/src/listener.py uses the index of
+# the finalizer in the list to generate its name when not defined, this leads to a change in the expected output.
+(pytest_major_version, pytest_minor_version, _) = pytest.version_tuple
+if pytest_major_version >= 9 and pytest_minor_version >= 1:
+    finalizer_index = "1"
+else:
+    finalizer_index = "0"
 
 @allure.feature("Fixture")
 @pytest.mark.parametrize("first_scope", fixture_scopes)
@@ -287,7 +296,7 @@ def test_fixture_override(allure_pytest_runner: AllurePytestRunner):
                     has_step("Step in before in original fixture")
                 ),
                 has_after(
-                    "my_fixture::0",
+                    f"my_fixture::{finalizer_index}",
                     has_step("Step in after in original fixture")
                 )
             ),
@@ -298,7 +307,7 @@ def test_fixture_override(allure_pytest_runner: AllurePytestRunner):
                     has_step("Step in before in redefined fixture")
                 ),
                 has_after(
-                    "my_fixture::0",
+                    f"my_fixture::{finalizer_index}",
                     has_step("Step in after in redefined fixture")
                 )
             )
@@ -356,18 +365,18 @@ def test_dynamically_called_fixture(
                 has_container(
                     allure_results,
                     has_before("parent_auto_call_fixture"),
-                    has_after("parent_auto_call_fixture::0")
+                    has_after(f"parent_auto_call_fixture::{finalizer_index}")
                 ),
                 has_container(
                     allure_results,
                     has_before("child_manual_call_fixture"),
-                    has_after("child_manual_call_fixture::0")
+                    has_after(f"child_manual_call_fixture::{finalizer_index}")
                 ),
                 not_(
                     has_container(
                         allure_results,
                         has_before("parent_dyn_call_fixture"),
-                        has_after("parent_dyn_call_fixture::0")
+                        has_after(f"parent_dyn_call_fixture::{finalizer_index}")
                     ),
                 ),
                 not_(
@@ -382,19 +391,19 @@ def test_dynamically_called_fixture(
                 has_container(
                     allure_results,
                     has_before("parent_auto_call_fixture"),
-                    has_after("parent_auto_call_fixture::0")
+                    has_after(f"parent_auto_call_fixture::{finalizer_index}")
                 ),
                 not_(
                     has_container(
                         allure_results,
                         has_before("child_manual_call_fixture"),
-                        has_after("child_manual_call_fixture::0")
+                        has_after(f"child_manual_call_fixture::{finalizer_index}")
                     ),
                 ),
                 has_container(
                     allure_results,
                     has_before("parent_dyn_call_fixture"),
-                    has_after("parent_dyn_call_fixture::0")
+                    has_after(f"parent_dyn_call_fixture::{finalizer_index}")
                 ),
                 has_container(
                     allure_results,
@@ -406,19 +415,19 @@ def test_dynamically_called_fixture(
                 has_container(
                     allure_results,
                     has_before("parent_auto_call_fixture"),
-                    has_after("parent_auto_call_fixture::0")
+                    has_after(f"parent_auto_call_fixture::{finalizer_index}")
                 ),
                 not_(
                     has_container(
                         allure_results,
                         has_before("child_manual_call_fixture"),
-                        has_after("child_manual_call_fixture::0")
+                        has_after(f"child_manual_call_fixture::{finalizer_index}")
                     ),
                 ),
                 has_container(
                     allure_results,
                     has_before("parent_dyn_call_fixture"),
-                    has_after("parent_dyn_call_fixture::0")
+                    has_after(f"parent_dyn_call_fixture::{finalizer_index}")
                 ),
                 not_(
                     has_container(


### PR DESCRIPTION
### Context

Resolves #834. This change will allow allure-python to be used on FIPS-compliant hosts. This change is a no-op on unrestricted (FIPS disabled) hosts.

When allure-python is executed on a host with FIPS mode enabled, an exception is thrown due to md5 being an insecure hash function:
```python
_hashlib.UnsupportedDigestmodError: [digital envelope routines] unsupported
```

See https://docs.python.org/3/library/hashlib.html#hashlib.md5

"_Changed in version 3.9_: All hashlib constructors take a keyword-only argument "usedforsecurity" with default value True. A false value allows the use of insecure and blocked hashing algorithms in restricted environments. False indicates that the hashing algorithm is not used in a security context, e.g. as a non-cryptographic one-way compression function."

This argument may be set to False because this project does not use md5 in a security context.

### Testing

I have a FIPS-enabled host where I am running pytest with the allure-pytest plugin in a container. Without this change, every test reports ERROR state due to encountering the above exception while executing part of the allure-pytest library. After manually patching allure_commons/utils.py in the container to use hashlib.md5(usedforsecurity=False) and rerunning the tests, all tests pass as expected.

I also ran the patched container on an unrestricted host to verify usedforsecurity=False does not have an effect.

#### Checklist
- [x] [Sign Allure CLA][cla]

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
