### PR TITLE
Prevent excluded Behave steps from leaking into results (fixes #902)

### DIFF
--- a/allure-behave/src/listener.py
+++ b/allure-behave/src/listener.py
@@ -108,6 +108,7 @@ class AllureListener:
         should_drop_excluded = self.hide_excluded and (scenario.skip_reason == TEST_PLAN_SKIP_REASON or not should_run)
 
         if should_drop_skipped_by_option or should_drop_excluded:
+            self.steps.clear()
             self.logger.drop_test(self.current_scenario_uuid)
         else:
             status = scenario_status(scenario)

--- a/tests/allure_behave/acceptance/behave_support/behave_cmd/behave_cmd_test.py
+++ b/tests/allure_behave/acceptance/behave_support/behave_cmd/behave_cmd_test.py
@@ -1,7 +1,7 @@
 from hamcrest import assert_that, all_of, not_
 from tests.allure_behave.behave_runner import AllureBehaveRunner
 from allure_commons_test.report import has_test_case
-from allure_commons_test.result import with_status
+from allure_commons_test.result import has_title, with_status, with_steps
 
 
 def test_behave_tags_filter(docstring: str, behave_runner: AllureBehaveRunner):
@@ -59,6 +59,44 @@ def test_behave_no_skipped_support(docstring: str, behave_runner: AllureBehaveRu
             ),
             not_(
                 has_test_case("Scenario without tag")
+            )
+        )
+    )
+
+
+def test_hidden_tag_excluded_scenario_steps_are_not_reported(
+    docstring: str,
+    behave_runner: AllureBehaveRunner
+):
+    """Feature: Behave hidden tag-excluded scenario support
+
+    Scenario: Scenario without tag
+        Given an excluded step
+
+    @tag
+    Scenario: Scenario with tag
+        Given an included step
+    """
+    behave_runner.run_behave(
+        feature_literals=[docstring],
+        step_literals=[
+            "given('an excluded step')(lambda c:None)\n"
+            "given('an included step')(lambda c:None)"
+        ],
+        options=["--tags=tag", "-D", "AllureFormatter.hide_excluded=True"]
+    )
+    assert_that(
+        behave_runner.allure_results,
+        all_of(
+            not_(
+                has_test_case("Scenario without tag")
+            ),
+            has_test_case(
+                "Scenario with tag",
+                with_status("passed"),
+                with_steps(
+                    has_title("Given an included step")
+                )
             )
         )
     )


### PR DESCRIPTION
### Context

When `AllureFormatter.hide_excluded=True`, Behave still reports step declarations for tag-excluded scenarios to the formatter. The listener dropped those scenarios without clearing its pending step queue, so their steps were later attached to the next included scenario.

This change clears pending steps when a scenario is dropped and adds an acceptance test that verifies a selected scenario contains only its own step.

Fixes #902

#### Checklist
- [x] [Sign Allure CLA](https://cla-assistant.io/accept/allure-framework/allure2)
- [x] Provide unit tests

### Verification

- `python -m pytest tests/allure_behave -q` — 64 passed
- `python -m ruff check allure-behave tests/allure_behave` — all checks passed
- `git diff --check HEAD^ HEAD`